### PR TITLE
Documentation header links quick fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,7 +11,7 @@ body:
         Before posting a feature request
       description: |
         Please first search existing GitHub issues and documentation to make sure this request and relevant resolutions do not already exist:
-        https://github.com/XanaduAI/ft-stack/issues
+        https://github.com/XanaduAI/flamingpy/issues
       options:
         - label: I have searched existing GitHub issues and documentation to make sure the feature request and relevant resolutions do not already exist.
           required: true

--- a/doc/_static/faq.html
+++ b/doc/_static/faq.html
@@ -78,12 +78,12 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack/issues" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy/issues" target="_blank" rel="noopener noreferrer">
           <i class="fab fab fa-discourse pr-1"></i> Support
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy" target="_blank" rel="noopener noreferrer">
           <i class="fab fa-github pr-1"></i> GitHub
         </a>
       </li>

--- a/doc/_static/install.html
+++ b/doc/_static/install.html
@@ -78,12 +78,12 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack/issues" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy/issues" target="_blank" rel="noopener noreferrer">
           <i class="fab fab fa-discourse pr-1"></i> Support
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy" target="_blank" rel="noopener noreferrer">
           <i class="fab fa-github pr-1"></i> GitHub
         </a>
       </li>
@@ -125,7 +125,7 @@ pip install flamingpy
             <pre>
                 <code class="bash">
 # download and install the latest source code from GitHub for developers
-git clone https://github.com/XanaduAI/ft-stack.git
+git clone https://github.com/XanaduAI/flamingpy.git
 cd flamingpy
 python -m pip install -r dev-requirements.txt
 python setup.py develop # only installs Python libraries

--- a/doc/_static/quantumErrorCorrection.html
+++ b/doc/_static/quantumErrorCorrection.html
@@ -78,12 +78,12 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack/issues" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy/issues" target="_blank" rel="noopener noreferrer">
           <i class="fab fab fa-discourse pr-1"></i> Support
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy" target="_blank" rel="noopener noreferrer">
           <i class="fab fa-github pr-1"></i> GitHub
         </a>
       </li>

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -53,7 +53,7 @@ h1, h2, h3 {
 
 h1 {
     font-size: 38px;
-    padding: 10px 10px 10px 10px;
+    padding: 10px;
     margin: 20px 0 35px -45px;
     width: calc(100% + 90px);
 }
@@ -317,7 +317,7 @@ label {
 /* code */
 
 .tab-pane pre code {
-    padding: 0px 40px 0px 40px !important;
+    padding: 0px 40px !important;
     font-size: 120% !important;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,.16),0 2px 10px 0 rgba(0,0,0,.12);
     border-radius: 0 0 10px 10px;
@@ -384,7 +384,7 @@ pre {
     }
 
     .footer-relations {
-        padding: 12px 10px 12px 10px;
+        padding: 12px 10px;
         left: 0;
     }
 

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -88,7 +88,7 @@ h5 {
 
 
 .parallax {
-    box-shadow: inset 0px 18px 43px -14px rgba(0,0,0,0.44);
+    box-shadow: inset 0 18px 43px -14px rgba(0,0,0,0.44);
     background-attachment: fixed;
     background-position: center;
     background-repeat: no-repeat;
@@ -246,7 +246,7 @@ h4.card-title {
     content: "";
     border-bottom-color: #19b37b;
     position: absolute;
-    bottom: 0px;
+    bottom: 0;
     width: 0%;
     left: 5%;
     transition: .5s ease-in-out,padding .5s ease-in-out;
@@ -292,7 +292,7 @@ h4.card-title {
 }
 
 .nav-pills .active {
-    border-radius: 0px;
+    border-radius: 0;
     background-color: #b13a59 !important;
 }
 
@@ -317,7 +317,7 @@ label {
 /* code */
 
 .tab-pane pre code {
-    padding: 0px 40px !important;
+    padding: 0 40px !important;
     font-size: 120% !important;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,.16),0 2px 10px 0 rgba(0,0,0,.12);
     border-radius: 0 0 10px 10px;
@@ -340,8 +340,8 @@ pre {
 
 @media screen and (max-width:768px) {
     body {
-        padding: 0px;
-        margin: 0px;
+        padding: 0;
+        margin: 0;
         background-color: #fff;
     }
 
@@ -358,7 +358,7 @@ pre {
     }
 
     .body {
-        padding: 0px;
+        padding: 0;
     }
 
     p {
@@ -375,7 +375,7 @@ pre {
     }
 
     .nav-item:hover:after, .nav-item.active:after {
-        border-bottom: 0px !important;
+        border-bottom: 0 !important;
     }
 
     .footer-heading {

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -44,12 +44,12 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack/issues" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy/issues" target="_blank" rel="noopener noreferrer">
           <i class="fab fab fa-discourse pr-1"></i> Support
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/ft-stack" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" href="https://github.com/XanaduAI/flamingpy" target="_blank" rel="noopener noreferrer">
           <i class="fab fa-github pr-1"></i> GitHub
         </a>
       </li>

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -15,4 +15,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.4.10a1"
+__version__ = "0.4.10a1.post1"


### PR DESCRIPTION
## Context for changes

< Include a summarized description of the changes and fixed issues in the format below. You cannot place N/A here. >

- **Updated old FT-Stack links in docs header to FlamingPy pages**: 
    See [here](https://flamingpy.readthedocs.io/en/doc-improv/).


## Example usage and tests

- [x] Not Applicable


## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable


## Expected benefits and drawbacks

**Expected benefits:**
- Header links are now pointing to correct FlamingPy pages.

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [x] I have performed a self-review of these changes. I have checked my code and corrected misspellings to the best of my capacity. I have checked the [CodeFactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it is `B-` or higher. I also confirm that I have already merged other branches into this branch as required.
- [x] I have added context for corresponding changes in documentation and README.md as needed.
- [x] I have added new workflow CI tests for corresponding changes and these pass locally for me.
- [x] I have updated `_version.py` based on [semantic versioning](https://semver.org/). I recognize that the developers may create a Special Release including my changes.
