### PR TITLE
Use XST version on PyPI

### DIFF
--- a/doc/dev_requirements.txt
+++ b/doc/dev_requirements.txt
@@ -13,5 +13,4 @@ sphinx-automodapi>=0.13
 sphinx-copybutton>=0.4
 sphinxcontrib-bibtex>=0.4.2
 toml>=0.10.2
-# TODO: Use the Xanadu-Sphinx-Theme package on PyPI once it has been released.
-git+https://github.com/XanaduAI/xanadu-sphinx-theme@phoenix#egg=xanadu_sphinx_theme
+xanadu-sphinx-theme==0.1.0


### PR DESCRIPTION
## Context for changes

The first version of the [Xanadu Sphinx Theme](https://pypi.org/project/xanadu-sphinx-theme/) was released on PyPI yesterday. 

- **Documentation changes**:
    * Updated the Xanadu Sphinx Theme requirement to use the version of the XST hosted on PyPI.

## Example usage and tests

To install the Sphinx documentation requirements inside a Python environment, run
```console
$ cd doc
$ pip install -r dev_requirements.txt
```

## Performance results justifying changes

- [X] Not Applicable

## Workflow actions and tests

See the `Create Documentation` check.

## Expected benefits and drawbacks

**Expected benefits:**
- Sphinx documentation builds have better reproducibility across time.

**Possible drawbacks:**
- The version constraint of the XST dependency must be manually updated to access new XST features.

## Related Github issues

- [X] Not Applicable

## Checklist and integration statements

- [X] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [X] I have performed a self-review of these changes. I have checked my code and corrected misspellings to the best of my capacity. I have checked the [codefactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it is `A-` or better. I also confirm that I have already merged other branches into this branch as required.
- [X] I have added context for corresponding changes in documentation and README.md as needed.
- [X] I have added new workflow CI tests for corresponding changes and these pass locally for me.
- [X] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit `CHANGELOG.md` and the versioning, and create a Special Release including my changes. - **No changes are required since this change is transparent to users of FlamingPy.**

