### PR TITLE
Allow instantiation of CVLayer with code object + misc. changes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,11 @@
   `.coveragerc` as well as the refactoring of some examples to allow for proper
   imports from testing modules. Code coverage is now above 95% and
   the fail treshold is bumped accordingly. [(#14)](https://github.com/XanaduAI/flamingpy/pull/14)
+ * `CVLayer` has been modified to allow for instantiation with a code object
+  in addition to an `EGraph`. This makes more semantic sense (applying a noise model
+  to a code) and makes it easier for the user.
+ * The sometimes failing `test_hybridize` in `test_graphstates.py` has been fixed. 
+ * PR template has been changed to inform user about 95% + codecov requirement.
 
 ### Documentation changes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,9 +12,10 @@
   the fail treshold is bumped accordingly. [(#14)](https://github.com/XanaduAI/flamingpy/pull/14)
  * `CVLayer` has been modified to allow for instantiation with a code object
   in addition to an `EGraph`. This makes more semantic sense (applying a noise model
-  to a code) and makes it easier for the user.
- * The sometimes failing `test_hybridize` in `test_graphstates.py` has been fixed. 
- * PR template has been changed to inform user about 95% + codecov requirement.
+  to a code) and makes it easier for the user. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+ * The sometimes failing `test_hybridize` in `test_graphstates.py` has been fixed. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+ * PR template has been changed to inform user about 95% + codecov requirement. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+ * Introduced `codecov.yml` to customize codecov automated tests. For this version, we have added a `threshold: %0.01` to avoid undesired failures due to just removing a few lines, etc. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
 
 ### Documentation changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,5 +53,5 @@
 - [ ] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
 - [ ] I have performed a self-review of these changes, checked my code, and corrected misspellings to the best of my capacity. I have checked the [codefactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it remains at `A` level. I also confirm that I have already merged other branches into this branch as required.
 - [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
-- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 90% or better, and these pass locally for me.
+- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 95% or better, and these pass locally for me.
 - [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ RHG = SurfaceCode(3)
 The integer denotes the code distance. By default, the boundaries are set to "open". Next, let us associate the nodes in the RHG lattice with CV states:
 
 ```
-CVRHG = CVLayer(RHG.graph, p_swap=0.5)
+CVRHG = CVLayer(RHG, p_swap=0.5)
 ```
 
 Now, half the lattice (on average) will be labelled a GKP state, and the other half a p-squeezed state. Next, we can apply a noise model to the states:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.1%

--- a/doc/usage/getting_started.rst
+++ b/doc/usage/getting_started.rst
@@ -22,7 +22,7 @@ The integer denotes the code distance. By default, the boundaries are set to "op
 
 .. code-block:: python3
 
-   CVRHG = CVLayer(RHG.graph, p_swap=0.5)
+   CVRHG = CVLayer(RHG, p_swap=0.5)
 
 
 Now, half the lattice (on average) will be labelled a GKP state, and the other half a p-squeezed state. Next, we can apply a noise model to the states:

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -15,4 +15,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.6.1a3.dev1"
+__version__ = "0.6.1a3.dev2"

--- a/flamingpy/benchmarks/decoding.py
+++ b/flamingpy/benchmarks/decoding.py
@@ -56,10 +56,9 @@ for backend in ["networkx", "retworkx"]:
     RHG_code = SurfaceCode(
         distance=distance, boundaries=boundaries, polarity=alternating_polarity, backend=backend
     )
-    RHG_lattice = RHG_code.graph
     for i in range(num_trials):
         print(f"-- {i} --")
-        CVRHG = CVLayer(RHG_lattice, p_swap=p_swap)
+        CVRHG = CVLayer(RHG_code, p_swap=p_swap)
         # Apply noise
         CVRHG.apply_noise(cv_noise)
         # Measure syndrome

--- a/flamingpy/benchmarks/matching.py
+++ b/flamingpy/benchmarks/matching.py
@@ -33,7 +33,6 @@ num_trials = 10
 distance = 3
 boundaries = "periodic"
 RHG_code = SurfaceCode(distance=distance, boundaries=boundaries, polarity=alternating_polarity)
-RHG_lattice = RHG_code.graph
 
 # Noise model parameters
 p_swap = 0.2
@@ -67,7 +66,7 @@ for alg in ["networkx", "lemon", "retworkx"]:
     for i in range(num_trials):
         print(f"-- {i} --")
         # Instantiate the CV layer
-        CVRHG = CVLayer(RHG_lattice, p_swap=p_swap)
+        CVRHG = CVLayer(RHG_code, p_swap=p_swap)
         # Apply noise
         CVRHG.apply_noise(cv_noise)
         # Measure syndrome

--- a/flamingpy/benchmarks/shortest_path.py
+++ b/flamingpy/benchmarks/shortest_path.py
@@ -56,10 +56,9 @@ for backend in ["networkx", "retworkx"]:
     RHG_code = SurfaceCode(
         distance=distance, boundaries=boundaries, polarity=alternating_polarity, backend=backend
     )
-    RHG_lattice = RHG_code.graph
     for i in range(num_trials):
         print(f"-- {i} --")
-        CVRHG = CVLayer(RHG_lattice, p_swap=p_swap)
+        CVRHG = CVLayer(RHG_code, p_swap=p_swap)
         # Apply noise
         CVRHG.apply_noise(cv_noise)
         # Measure syndrome

--- a/flamingpy/benchmarks/simulations.py
+++ b/flamingpy/benchmarks/simulations.py
@@ -62,7 +62,6 @@ def ec_monte_carlo(code, trials, delta, p_swap, passive_objects=None, backend="c
         decoder = {"outer": "MWPM"}
         weight_options = {"method": "blueprint", "prob_precomputed": True}
     else:
-        code_lattice = code.graph
         # Noise model
         # Decoding options
         decoder = {"inner": "basic", "outer": "MWPM"}
@@ -79,7 +78,7 @@ def ec_monte_carlo(code, trials, delta, p_swap, passive_objects=None, backend="c
                 reduce_macro_and_simulate(*passive_objects, p_swap, delta)
             else:
                 # Apply noise
-                CVRHG = CVLayer(code_lattice, p_swap=p_swap)
+                CVRHG = CVLayer(code, p_swap=p_swap)
                 CVRHG.apply_noise(cv_noise)
                 # Measure syndrome
                 CVRHG.measure_hom("p", code.all_syndrome_inds)
@@ -112,7 +111,7 @@ def run_sims_benchmark(distance, ec, boundaries, delta, p_swap, trials, passive,
         RHG_macro.index_generator()
         RHG_macro.adj_generator(sparse=True)
         # The empty CV state, uninitiated with any error model.
-        CVRHG_reduced = CVLayer(RHG_lattice)
+        CVRHG_reduced = CVLayer(RHG_code)
         # Define the 4X4 beamsplitter network for a given macronode.
         # star at index 0, planets at indices 1-3.
         bs_network = BS_network(4)

--- a/flamingpy/cv/ops.py
+++ b/flamingpy/cv/ops.py
@@ -123,10 +123,13 @@ class CVLayer:
             indices to coordinates.
     """
 
-    def __init__(self, g, states=None, p_swap=0, rng=default_rng()):
+    def __init__(self, code, states=None, p_swap=0, rng=default_rng()):
         """Initialize the CVGraph."""
-        self.egraph = g
-        self._N = len(g)
+        if code.__class__.__name__ == "EGraph":
+            self.egraph = code
+        else:
+            self.egraph = code.graph
+        self._N = len(self.egraph)
 
         self._init_quads = None
         self._noise_cov = None

--- a/flamingpy/examples/decoding.py
+++ b/flamingpy/examples/decoding.py
@@ -33,12 +33,11 @@ def decode_surface_code(distance, boundaries, ec, noise, draw=True, show=False):
     RHG_code = SurfaceCode(
         distance=distance, ec=ec, boundaries=boundaries, polarity=alternating_polarity
     )
-    RHG_lattice = RHG_code.graph
 
     if noise == "cv":
         # CV (inner) code / state preparation
         p_swap = 0.05  # probability of having squeezed states (the rest are GKPs)
-        CVRHG = CVLayer(RHG_lattice, p_swap=p_swap)
+        CVRHG = CVLayer(RHG_code, p_swap=p_swap)
         # Noise model
         delta = 0.1  # GKP squeezing parameter
         cv_noise = {"noise": "grn", "delta": delta, "sampling_order": "initial"}

--- a/flamingpy/examples/macro_reduce.py
+++ b/flamingpy/examples/macro_reduce.py
@@ -39,7 +39,7 @@ RHG_macro.index_generator()
 RHG_macro.adj_generator(sparse=True)
 
 # The empty CV layer, uninitiated with any error model.
-CVRHG_reduced = CVLayer(RHG_reduced)
+CVRHG_reduced = CVLayer(RHG_code)
 # Define the 4X4 beamsplitter network for a given macronode.
 # star at index 0, planets at indices 1-3.
 bs_network = BS_network(4)

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -47,7 +47,6 @@ def ec_monte_carlo(code, trials, delta, p_swap, passive_objects=None):
         decoder = {"outer": "MWPM"}
         weight_options = {"method": "blueprint", "prob_precomputed": True}
     else:
-        code_lattice = code.graph
         # Noise model
         cv_noise = {"noise": "grn", "delta": delta, "sampling_order": "initial"}
         # Decoding options
@@ -65,7 +64,7 @@ def ec_monte_carlo(code, trials, delta, p_swap, passive_objects=None):
             reduce_macro_and_simulate(*passive_objects, p_swap, delta)
         else:
             # Apply noise
-            CVRHG = CVLayer(code_lattice, p_swap=p_swap)
+            CVRHG = CVLayer(code, p_swap=p_swap)
             # Measure syndrome
             CVRHG.apply_noise(cv_noise)
             CVRHG.measure_hom("p", code.all_syndrome_inds)

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -42,9 +42,8 @@ def enc_state(request):
     """An RHGCode object and an encoded CVLayer for use in this module."""
     distance, ec, boundaries, delta, p_swap = request.param
     DVRHG = SurfaceCode(distance, ec, boundaries, alternating_polarity)
-    RHG_lattice = DVRHG.graph
     # CV (inner) code/state
-    CVRHG = CVLayer(RHG_lattice, p_swap=p_swap)
+    CVRHG = CVLayer(DVRHG, p_swap=p_swap)
     # Noise model
     cv_noise = {"noise": "grn", "delta": delta, "sampling_order": "initial"}
     # Apply noise

--- a/tests/unit/test_graphstates.py
+++ b/tests/unit/test_graphstates.py
@@ -160,7 +160,7 @@ class TestCVLayer:
         assert np.array_equal(G._states["GKP"], np.arange(n))
         assert np.array_equal(G.GKP_inds, np.arange(n))
 
-    @pytest.mark.parametrize("p_swap", [0, rng().random(), 1])
+    @pytest.mark.parametrize("p_swap", [0, 0.99 * rng().random() + 0.01, 1])
     def test_hybridize(self, random_graph, p_swap):
         """Test whether CVLayer properly populates p-squeezed states for non-
         zero p-swap."""

--- a/tests/unit/test_graphstates.py
+++ b/tests/unit/test_graphstates.py
@@ -24,6 +24,7 @@ from numpy.random import default_rng as rng
 import pytest
 import scipy.sparse as sp
 
+from flamingpy.codes import SurfaceCode
 from flamingpy.codes.graphs import EGraph
 from flamingpy.cv.ops import CVLayer, SCZ_mat, SCZ_apply
 
@@ -136,7 +137,7 @@ class TestCVLayer:
     """Tests for functions in the CVLayer class."""
 
     def test_empty_init(self, random_graph):
-        """Test the empty initialization of an EGraph."""
+        """Test the instantiation of CVLayer from codes and EGraphs."""
         G = CVLayer(random_graph[0], states=None)
         G_array = nx.to_numpy_array(G.egraph)
         H = CVLayer(EGraph(random_graph[0]), states=None)
@@ -148,6 +149,8 @@ class TestCVLayer:
         # a regular NetworkX graph has the same effect.
         assert np.array_equal(random_graph[1], H_array)
         assert np.array_equal(random_graph[1], G_array)
+        CVRHG = CVLayer(SurfaceCode(2))
+        assert CVRHG._N == len(SurfaceCode(2).graph)
 
     def test_all_GKP_init(self, random_graph):
         """Test the all-GKP initialization of EGraph."""

--- a/tests/unit/test_simulations.py
+++ b/tests/unit/test_simulations.py
@@ -70,7 +70,7 @@ class TestPassive:
         RHG_macro.adj_generator(sparse=True)
 
         # The empty CV state, uninitiated with any error model.
-        CVRHG_reduced = CVLayer(code.graph)
+        CVRHG_reduced = CVLayer(code)
 
         # Define the 4X4 beamsplitter network for a given macronode.
         # star at index 0, planets at indices 1-3.

--- a/tests/unit/test_stabilizer_graph.py
+++ b/tests/unit/test_stabilizer_graph.py
@@ -68,9 +68,8 @@ def compute_enc_state(request):
     nx_DVRHG = SurfaceCode(
         distance=distance, ec=ec, boundaries=boundaries, polarity=alternating_polarity
     )
-    nx_RHG_lattice = nx_DVRHG.graph
     # CV (inner) code/state
-    nx_CVRHG = CVLayer(nx_RHG_lattice, p_swap=p_swap)
+    nx_CVRHG = CVLayer(nx_DVRHG, p_swap=p_swap)
     # Apply noise
     nx_CVRHG.apply_noise(cv_noise, default_rng(seed))
     # Measure syndrome
@@ -87,10 +86,9 @@ def compute_enc_state(request):
         polarity=alternating_polarity,
         backend=backend,
     )
-    RHG_lattice = DVRHG.graph
     # CV (inner) code/state
     states = {"p": nx_CVRHG._states["p"]}
-    CVRHG = CVLayer(RHG_lattice, states)
+    CVRHG = CVLayer(DVRHG, states)
     # Apply noise
     CVRHG.apply_noise(cv_noise, default_rng(seed))
     # Measure syndrome


### PR DESCRIPTION
## Context for changes

- **Improvements**: 
    * CVLayer can now be instantiated with a code object in addition to an EGraph.
    * test_hybridize in test_graph_states no longer fails.
    * PR template changed to notify the users about 95% + codecov requirement.
    * Introduced `codecov.yml` to customize codecov automated tests. For this version, we have added a `threshold: %0.01` to avoid undesired failures due to just removing a few lines, etc.

## Example usage and tests

```
RHG_code = SurfaceCode(2)
CVRHG = CVLayer(RHG_code)
```
(rather than `CVLayer(RHG_code.graph)`)

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

Tests that used to feed code.graph to CVLayer now just feed code. A couple of lines have also been added to test_empty_init in TestCVLayer.

## Expected benefits and drawbacks

**Expected benefits:**
- User no longer has to extract the EGraph from the code before applying CVLayer. This saves a line of code, and makes it more intuitive.
- test_hybridize no longer fails.
- User now knows to maintain high code coverage.

**Possible drawbacks:**
- Every time CVLayer is instantiated, it checks whether the code argument is a SurfaceCode object. This takes a small amount of time. Eventually this will have to be generalized to abstract code objects.

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [ ] I have performed a self-review of these changes, checked my code, and corrected misspellings to the best of my capacity. I have checked the [codefactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it remains at `A` level. I also confirm that I have already merged other branches into this branch as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 90% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
