### PR TITLE
Fix dual stabilizers positioning when drawing

### DIFF
--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -622,9 +622,6 @@ def _plot_cube_at(positions, sizes=None, colors=None, **kwargs):
 def _cuboid_data(origin, size=(1, 1, 1)):
     """Return an array with the corners of a cube of size 1."""
 
-    The cube is scaled by `size` in each direction and tranlated by
-    `origin`.
-    """
     X = np.array(
         [
             [[0, 1, 0], [0, 0, 0], [1, 0, 0], [1, 1, 0]],

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -576,9 +576,9 @@ def syndrome_plot(code, ec, index_dict=None, drawing_opts=None):
     ax.add_collection3d(pc)
 
     # setting plot limits to give some room to the boxes
-    ax.set_xlim(-2, 2 * shape[0] + 1)
-    ax.set_ylim(-2, 2 * shape[1] + 1)
-    ax.set_zlim(-2, 2 * shape[2] + 1)
+    ax.set_xlim(-1, 2 * shape[0])
+    ax.set_ylim(-1, 2 * shape[1])
+    ax.set_zlim(-1, 2 * shape[2])
 
     if drawing_opts["label_boundary"]:
         bound_points = getattr(code, ec + "_bound_points")

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -542,7 +542,7 @@ def syndrome_plot(code, ec, index_dict=None, drawing_opts=None):
     for cube in cubes:
 
         # Obtain smallest, largest, and middle coordinates for each
-        # cube. Divided by 2 because voxels are 1X1X1.
+        # cube.
         xmin, xmax = np.array(cube.xlims())
         ymin, ymax = np.array(cube.ylims())
         zmin, zmax = np.array(cube.zlims())
@@ -555,10 +555,10 @@ def syndrome_plot(code, ec, index_dict=None, drawing_opts=None):
 
         # gap defines the distance between adjacent cubes
         gap = 0.15
-        positions.append(np.array([xmin, ymin, zmin]) + gap)
-        sizes.append(
-            np.array([np.abs(xmax - xmin), np.abs(ymax - ymin), np.abs(zmax - zmin)]) - 2 * gap
-        )
+        min_arr = np.array([xmin, ymin, zmin])
+        max_arr = np.array([xmax, ymax, zmax])
+        positions.append(min_arr + gap)
+        sizes.append(np.abs(max_arr - min_arr) - 2 * gap)
         colors.append(color)
 
         if drawing_opts["label_cubes"] and index_dict:
@@ -620,8 +620,7 @@ def _plot_cube_at(positions, sizes=None, colors=None, **kwargs):
 
 
 def _cuboid_data(origin, size=(1, 1, 1)):
-    """This functions defines an array containing the corners of cube of size
-    one.
+    """Return an array with the corners of a cube of size 1."""
 
     The cube is scaled by `size` in each direction and tranlated by
     `origin`.

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -572,7 +572,7 @@ def syndrome_plot(code, ec, index_dict=None, drawing_opts=None):
                 )
 
     # draw cubes
-    pc = _plot_cube_at(positions, colors=colors, sizes=sizes)
+    pc = _plot_cubes_at(positions, colors=colors, sizes=sizes)
     ax.add_collection3d(pc)
 
     # setting plot limits to give some room to the boxes
@@ -613,7 +613,28 @@ def syndrome_plot(code, ec, index_dict=None, drawing_opts=None):
     return fig, ax
 
 
-def _plot_cube_at(positions, sizes=None, colors=None, **kwargs):
+def _plot_cubes_at(positions, sizes=None, colors=None, **kwargs):
+    """Plot cubes with their origin located at ``positions``.
+
+    Note cubes are located by displacing them from the origin. In that sense,
+    the location is defined by the corner matching the origin of the coordinate
+    system before displacement.
+
+    Args:
+        positions (Iterable): An interable of dimension ``(N,3)`` containing the
+            position of the corner of the cube.
+        sizes (Iterable): An interable of dimension ``(N,3)`` containing the size of
+            the cube in the coordinate directions.
+        colors (Iterable): An iterable of size ``N`` containing the colors of the cube.
+            This can be any of the option allowed by matplolib.
+
+    Keyword arguments:
+        **kwargs: all other parameters are forwarded to
+            ```Poly3DColletion`` <https://matplotlib.org/stable/api/_as_gen/mpl_toolkits.mplot3d.art3d.Poly3DCollection.html>`_.
+
+    Returs:
+        Poly3DCollection: A collection of 3D polygons defining the cubes.
+    """
 
     g = [_cuboid_data(p, size=s) for p, s in zip(positions, sizes)]
     return Poly3DCollection(np.concatenate(g), facecolors=np.repeat(colors, 6, axis=0), **kwargs)


### PR DESCRIPTION
## Context for changes

When illustrating the "dual" error complex, dual stabilizers should be plotted. However, the cubes are not positioned correctly: they are at the locations of primal stabilizers (see image below).

![image](https://user-images.githubusercontent.com/675763/167211997-aa19a04a-b7ce-40c3-b620-291ca6562955.png)

- **New features**:
    * This PR refactors the voxel plotting function to allow for easy location in space as well as resizing (note the resizing feature is important for incomplete stabilizers at boundaries that are represented by incomplete cubes). The mentioned changes implement two new functions into the `viz` module: `_plot_cube_at` creates a `Poly3DCollection` with the designated facecolor and other graphical properties and `_cuboid_data` just creates, scales, and locates a cube in space. 
- **Bug fixes**: 
    * Before only integer locations and cube sizes were allowed. Even more, no cube could be placed in a coordinate with values lover than zero. 
- **Improvements**: 
    * The offered method to draw voxels is much more clear and has an easier to use API.
- **Documentation changes**:
    * None

## Example usage and tests

Just use as before. This is an example of the result.

![image](https://user-images.githubusercontent.com/675763/167213608-5084c2ea-fd81-4a0c-bd62-6607b2fd15c8.png)

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable

## Expected benefits and drawbacks

**Expected benefits:**
- Correct visualization of dual cells.

**Possible drawbacks:**
- None

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [x] I have performed a self-review of these changes, checked my code, and corrected misspellings to the best of my capacity. I have checked the [codefactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it remains at `A` level. I also confirm that I have already merged other branches into this branch as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 90% or better, and these pass locally for me.
- NOT REQUIRED (nor merging directly to master): I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
