### PR TITLE
Re-add The Walrus to FlamingPy

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,14 +10,13 @@
   `.coveragerc` as well as the refactoring of some examples to allow for proper
   imports from testing modules. Code coverage is now above 95% and
   the fail treshold is bumped accordingly. [(#14)](https://github.com/XanaduAI/flamingpy/pull/14)
- * `CVLayer` has been modified to allow for instantiation with a code object
+* `CVLayer` has been modified to allow for instantiation with a code object
   in addition to an `EGraph`. This makes more semantic sense (applying a noise model
   to a code) and makes it easier for the user. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
- * The sometimes failing `test_hybridize` in `test_graphstates.py` has been fixed. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
- * PR template has been changed to inform user about 95% + codecov requirement. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
- * Introduced `codecov.yml` to customize codecov automated tests. For this version, we have added a `threshold: %0.01` to avoid undesired failures due to just removing a few lines, etc. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
-
-* The walrus is re-added as a dependency and its functions used instead of a verbatim
+* The sometimes failing `test_hybridize` in `test_graphstates.py` has been fixed. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+* PR template has been changed to inform user about 95% + codecov requirement. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+* Introduced `codecov.yml` to customize codecov automated tests. For this version, we have added a `threshold: %0.01` to avoid undesired failures due to just removing a few lines, etc. [(#25)](https://github.com/XanaduAI/flamingpy/pull/25)
+* The Walrus is re-added as a dependency and its functions used instead of a verbatim
   copy of the code. [(#27)](https://github.com/XanaduAI/flamingpy/pull/27)
 
 ### Documentation changes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,9 @@
   imports from testing modules. Code coverage is now above 95% and
   the fail treshold is bumped accordingly. [(#14)](https://github.com/XanaduAI/flamingpy/pull/14)
 
+* The walrus is re-added as a dependency and its functions used instead of a verbatim
+  copy of the code. [(#27)](https://github.com/XanaduAI/flamingpy/pull/27)
+
 ### Documentation changes
 
 ### Contributors

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,3 +13,4 @@ pytest-logger>=0.5.1
 pytest-mock>=3.6.1
 retworkx>=0.10.2
 scipy>=1.6
+thewalrus>=0.19.0

--- a/doc/build_docs.rst
+++ b/doc/build_docs.rst
@@ -17,6 +17,7 @@ The FlamingPy documentation is built using `sphinx`. To build the documentation 
 * `sphinx-autodoc-typehints <https://pypi.org/project/sphinx-autodoc-typehints/>`_ >= 1.10.3
 * `sphinx-automodapi <https://sphinx-automodapi.readthedocs.io/en/latest/>`_ >= 0.13
 * `sphinx-copybutton <https://sphinx-copybutton.readthedocs.io/en/latest/>`_ >= 0.4
+* `thewalrus <https://the-walrus.readthedocs.io/en/latest/>`_ >= 0.19.0
 * `toml <https://pypi.org/project/toml/>`_ >= 0.10.2
 
 All required packages can be installed via:

--- a/doc/dev_requirements.txt
+++ b/doc/dev_requirements.txt
@@ -12,5 +12,6 @@ sphinx-autodoc-typehints>=1.10.3
 sphinx-automodapi>=0.13
 sphinx-copybutton>=0.4
 sphinxcontrib-bibtex>=0.4.2
+thewalrus>=0.19.0
 toml>=0.10.2
 xanadu-sphinx-theme>=0.1.0

--- a/doc/development/guide_for_devs.rst
+++ b/doc/development/guide_for_devs.rst
@@ -25,6 +25,7 @@ as well as the following Python packages for development purposes:
 * `pytest-mock <https://pypi.org/project/pytest-mock/>`_ >= 3.6.1
 * `retworkx <https://qiskit.org/documentation/retworkx/>`_ >= 0.10.2
 * `scipy <https://scipy.org/>`_ >= 1.6
+* `thewalrus <https://the-walrus.readthedocs.io/en/latest/>`_ >= 0.19.0
 
 If you currently do not have Python 3 installed, we recommend
 `Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed version

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -15,4 +15,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.6.1a3.dev2"
+__version__ = "0.6.1a3.dev3"

--- a/flamingpy/cv/macro_reduce.py
+++ b/flamingpy/cv/macro_reduce.py
@@ -20,74 +20,7 @@ from scipy.linalg import block_diag
 
 from flamingpy.cv.ops import CVLayer, SCZ_apply
 from flamingpy.cv.gkp import GKP_binner, Z_err_cond
-
-
-def expand(S, modes, N):
-    r"""Expands a Symplectic matrix S to act on the entire subsystem.
-    Args:
-        S (array): a :math:`2M\times 2M` Symplectic matrix
-        modes (Sequence[int]): the list of modes S acts on
-        N (int): full size of the subsystem
-    Returns:
-        array: the resulting :math:`2N\times 2N` Symplectic matrix
-    Note:
-        This is from thewalrus library.
-        https://github.com/XanaduAI/thewalrus/blob/master/thewalrus/symplectic.py
-    """
-    M = len(S) // 2
-    S2 = np.identity(2 * N, dtype=S.dtype)
-    w = np.array(modes)
-
-    S2[w.reshape(-1, 1), w.reshape(1, -1)] = S[:M, :M].copy()  # X
-    S2[(w + N).reshape(-1, 1), (w + N).reshape(1, -1)] = S[M:, M:].copy()  # P
-    S2[w.reshape(-1, 1), (w + N).reshape(1, -1)] = S[:M, M:].copy()  # XP
-    S2[(w + N).reshape(-1, 1), w.reshape(1, -1)] = S[M:, :M].copy()  # PX
-
-    return S2
-
-
-def beam_splitter(theta, phi, dtype=np.float64):
-    """Beam-splitter.
-
-    Args:
-        theta (float): transmissivity parameter
-        phi (float): phase parameter
-        dtype (numpy.dtype): datatype to represent the Symplectic matrix
-    Returns:
-        array: symplectic-orthogonal transformation matrix of an interferometer
-        with angles theta and phi
-    Note:
-        This is from thewalrus library.
-        https://github.com/XanaduAI/thewalrus/blob/master/thewalrus/symplectic.py
-    """
-    ct = np.cos(theta, dtype=dtype)
-    st = np.sin(theta, dtype=dtype)
-    eip = np.cos(phi, dtype=dtype) + 1j * np.sin(phi, dtype=dtype)
-    U = np.array(
-        [
-            [ct, -eip.conj() * st],
-            [eip * st, ct],
-        ]
-    )
-    return interferometer(U)
-
-
-def interferometer(U):
-    """Interferometer.
-
-    Args:
-        U (array): unitary matrix
-    Returns:
-        array: symplectic transformation matrix
-    Note:
-        This is from thewalrus library.
-        https://github.com/XanaduAI/thewalrus/blob/master/thewalrus/symplectic.py
-    """
-    X = U.real
-    Y = U.imag
-    S = np.block([[X, -Y], [Y, X]])
-
-    return S
+from thewalrus.symplectic import expand, beam_splitter
 
 
 def invert_permutation(p):

--- a/setup.py
+++ b/setup.py
@@ -153,8 +153,8 @@ install_requires = [
     "matplotlib>=3.3.3",
     "networkx>=2.5",
     "numpy>=1.21",
-    "retworkx>=0.10.2",
     "pandas>=1.2.1",
+    "retworkx>=0.10.2",
     "scipy>=1.6",
     "thewalrus>=0.19.0"
 ]

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ install_requires = [
     "retworkx>=0.10.2",
     "pandas>=1.2.1",
     "scipy>=1.6",
+    "thewalrus>=0.19.0"
 ]
 
 description = """FlamingPy is a cross-platform Python library with a variety of backends for


### PR DESCRIPTION
## Context for changes

The walrus was removed earlier due to version incompatibility and the required functions copied verbatim to FlamingPy. 

- **New features**:
    * The walrus is re-added to FlamingPy
- **Bug fixes**: 
    * None
- **Improvements**: 
    * Removed repeated code
- **Documentation changes**:
    * None

## Example usage and tests

- [x] Not Applicable

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable

## Expected benefits and drawbacks

Code duplication from the walrus is removed.

**Expected benefits:**
- Easier maintenance

**Possible drawbacks:**
- None

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [x] I have performed a self-review of these changes, checked my code, and corrected misspellings to the best of my capacity. I have checked the [codefactor score](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) in the active branch and ensured it remains at `A` level. I also confirm that I have already merged other branches into this branch as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 90% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
