### PR TITLE
[Discussion] Make noise models immutable

### DIFF
--- a/flamingpy/codes/surface_code.py
+++ b/flamingpy/codes/surface_code.py
@@ -321,6 +321,9 @@ class SurfaceCode:
                 raise ValueError("Invalid backend; options are 'networkx' and 'retworkx'.")
             setattr(self, error_type + "_stab_graph", stabilizer_graph)
 
+    def __len__(self):
+        return len(self.graph.nodes)
+    
     def identify_stabilizers(self):
         """Set the stabilizer and syndrome coordinates of self.
 
@@ -462,6 +465,17 @@ class SurfaceCode:
                 final_high_set = set(high_bound_points).intersection(syndrome_coords)
 
                 setattr(self, ec + "_bound_points", list(final_low_set) + list(final_high_set))
+    
+    def apply_error(self, error):
+        """Update the "bit_val" attribute of each node in the graph of the code
+        from the error bitstring.
+        
+        Args:
+            error (sequence of 0s and 1s):
+                The element at index i is set as the "bit_val" attribute of node i.
+        """
+        for (err, (_, node_data)) in zip(error, self.graph.nodes.data()):
+            node_data["bit_val"] = err
 
     def draw(self, **kwargs):
         """Draw the cluster state with matplotlib.

--- a/flamingpy/noise/base.py
+++ b/flamingpy/noise/base.py
@@ -1,0 +1,29 @@
+from abc import ABC
+from numpy.random import default_rng
+
+class Noise(ABC):
+    def sample(self, rng=default_rng()):
+        raise NotImplementedError
+
+    def transform(self, input):
+        raise NotImplementedError
+
+    def chain(self, other):
+        return ChainedNoise(self, other)
+        
+
+class ChainedNoise(Noise):
+    def __init__(self, sampler, transformer):
+        self.sampler = sampler,
+        self.transformer = transformer
+
+    def sample(self, rng=default_rng()):
+        error = self.sampler.sample(rng)
+        return self.transformer.transform(error)
+
+
+def chain_noises(*models):
+    model = models[0]
+    for m in models[1:]:
+        model = model.chain(m)
+    return model

--- a/flamingpy/noise/iid.py
+++ b/flamingpy/noise/iid.py
@@ -14,6 +14,7 @@
 """An implementation of IID Pauli noise."""
 
 from numpy.random import default_rng
+import numpy as np
 
 
 class IidNoise:
@@ -25,21 +26,23 @@ class IidNoise:
         error_probability (float): the probability of a Z error.
     """
 
-    def __init__(self, code, error_probability):
+    def __init__(self, length, error_probability):
         if error_probability < 0.0 or error_probability > 1.0:
             raise ValueError("Probability is not between 0 and 1.")
-        self.graph = code.graph
+        self.length = length
         self.error_probability = error_probability
 
-    def apply_noise(self, rng=default_rng()):
-        """Apply the noise to the code.
-
-        This fixes the "bit_val" attribute of each node in the code egraph.
+    def sample(self, rng=default_rng()):
+        """Generate a random error.
 
         Args:
             rng (numpy.random.Generator, optional): a random number generator
                 following the NumPy API. It can be seeded for reproducibility.
                 By default, numpy.random.default_rng is used without a fixed seed.
+
+        Returns (numpy.ndarray):
+            A bit string where each 1 represents
+            a Z error on the corresponding qubit.
+        
         """
-        for _, node_data in self.graph.nodes.data():
-            node_data["bit_val"] = int(rng.random() < self.error_probability)
+        return np.array(rng.random(self.length) < self.error_probability, dtype=int)

--- a/flamingpy/noise/iid.py
+++ b/flamingpy/noise/iid.py
@@ -15,9 +15,10 @@
 
 from numpy.random import default_rng
 import numpy as np
+from .base import Noise
 
 
-class IidNoise:
+class IidNoise(Noise):
     """Noise sampler for independent and identically distributed Z errors on
     the qubits of a cluster state.
 
@@ -46,3 +47,4 @@ class IidNoise:
         
         """
         return np.array(rng.random(self.length) < self.error_probability, dtype=int)
+    

--- a/tests/unit/test_iid_noise.py
+++ b/tests/unit/test_iid_noise.py
@@ -23,8 +23,9 @@ from flamingpy.decoders.decoder import correct
 def test_zero_noise():
     """Check that bit values are all 0 when the error probability is 0."""
     code = SurfaceCode(3)
-    noise = IidNoise(code, 0.0)
-    noise.apply_noise()
+    noise = IidNoise(len(code), 0.0)
+    error = noise.sample()
+    code.apply_error(error)
     for _, node_data in code.graph.nodes.data():
         assert node_data["bit_val"] == 0
 
@@ -32,8 +33,9 @@ def test_zero_noise():
 def test_full_noise():
     """Check that bit values are all 1 when the error probability is 1."""
     code = SurfaceCode(3)
-    noise = IidNoise(code, 1.0)
-    noise.apply_noise()
+    noise = IidNoise(len(code), 1.0)
+    error = noise.sample()
+    code.apply_error(error)
     for _, node_data in code.graph.nodes.data():
         assert node_data["bit_val"] == 1
 
@@ -44,8 +46,8 @@ def test_finite_prob_noise():
     """
     code = SurfaceCode(3)
     for prob in [0.1, 0.5, 0.9]:
-        noise = IidNoise(code, prob)
-        noise.apply_noise()
+        noise = IidNoise(len(code), prob)
+        code.apply_error(noise.sample())
         for _, node_data in code.graph.nodes.data():
             assert node_data["bit_val"] in [0, 1]
 
@@ -54,8 +56,8 @@ def test_decoding():
     """Check that we can use the correct function to decode the code
     after applying iid noise."""
     code = SurfaceCode(3)
-    noise = IidNoise(code, 0.1)
-    noise.apply_noise()
+    noise = IidNoise(len(code), 0.1)
+    code.apply_error(noise.sample())
     assert correct(code, {"outer": "MWPM"}) in [True, False]
 
 
@@ -65,6 +67,6 @@ def test_warning(prob):
 
     code = SurfaceCode(3)
     with pytest.raises(Exception) as exc:
-        IidNoise(code, prob)
+        IidNoise(len(code), prob)
 
     assert str(exc.value) == "Probability is not between 0 and 1."


### PR DESCRIPTION
## Context for changes

This is a first step toward an immutable API. This immutable API will have many benefits eventually by  

  - Simplifying the implementation of different components of flamingpy in faster lower-level programming languages (C, C++, Rust, Fortran ...)
  - Removing the connection between different components, thus making new algorithms easier to implement. For example, developers won't have to worry about implementation details of noise models and code classes when working on a decoder. 
  - Making it easier to test individual components in isolation.


However, this is a noble goal that we won't reach in a single day. This PR is the first step in that direction. The focus of this PR is to make it such that noise models don't need to update attributes of the surface code class. I am creating the PR sooner than usual to gather comments and feedbacks as soon as possible.

## Tasks

- [x] **Update iid noise to use an immutable API** 

  This first step is the simplest tasks of all. It involves only a few minor modifications of the IidNoise class to make it returns an error as a bit string instead of updating directly the surface code class. However, notice that since I don't want to update anything related to decoders in the PR, I added a new method to the surface code class to apply an error to the node attributes of its egraph. All combined, it looks like this.

```python
code = SurfaceCode(distance=5)

# The noise model only need to know how many qubits there are and nothing more about the code.
# Different noise model may need extra informations. For example,
# a correlated noise model would require information about the qubit adjacency.
# We also provide an error probability of 10%.
noise = IidNoise(len(code), 0.1) 

# We can also provide a seeded rng to make it reproducible.
# Also, that error could be applied to any code (not limited to surface codes)
# as long as it has the correct number of qubits.
# This could be hepful in the future to study different code constructions.
error = noise.sample()

# In the future, the error will be converted directly into a syndrome by the code 
# and then syndrome would be feeded to the decoder. 
# However, to keep the changes manageable, I started by adding this method
# that apply the error directly to code attributes.
code.apply_error(error)

# From there, you can use the usual process to decode the error.
```

- [ ] **When happy with iid noise, do a similar change to CVLayer** 

   One important consideration for CV noise is how to manage homodyne values translation. Do we want to wrap that in a compositor class that will behave like iid noise, do we want to define a more specialized noise model ourself or we want to user to be explicit when using different objects? For the user, here is how the the approachs could look.

### Compositor class

```python
# The sample method of this class should return a sequence of quadratures.
gaussian_noise = GaussianNoise(...) 

# This should have a transform method mapping quadratures to homodyne values.
homodyne_measurement = HomodyneMeasurement(...) 

# This should have a transform method mapping homodynes values to binary error values.
translator = CvTranslator(...) 

# This build the noise model.
# The resulting noise object has a sample method that is similar to one of the iid noise.
noise = compose_noise(gaussian_noise, homodyne_measurement, translator)

# From this point, noise is similar to the previous example.
error = noise.sample()
code.apply_error(error)

# The compose function will look like this. It could also be a stand-alone class.

def compose_noise(*models):
    class Noise:
        def sample(self, rng=np.random.default_rng()):
            error = models[0].sample(rng)
            for model in models[1:]:
                error = model.transform(error)
            return error
    return Noise
```

Notice that there are two building blocks for noise model:
- classes with a sample method
- classes with a transform method

Of course, a class can have both methods, but only classes with the sample method can be used as a final noise model. I feel that this approach is clean, easy to use and allow creation of more complex noise models without too much effort. 

### Specialized class

```python 
# Of course, many class arguments could be optional and we can provide nice defaults.
class CvNoise:
   def __init__(self, grn_arg_1, grn_arg_2, homodyne_arg_1, homodyne_arg_2, translator_arg_1, translator_arg_2):
        ...
       
   def sample(self, rng=np.random.default_rng()):
       gaussian_noise = self.sample_gaussian_noise(rng) 
       homodyne_values = self.generate_homodyne_values(gaussian_noise)
       return self.translator(homodyne_values)
       
    def sample_gaussian_noise(self, rng):
        # do something with self.grn_arg_1 and self.grn_arg_2
    
    def generate_homodyne_values(self, gaussian_noise):
        # do something with self.homodyne_arg_1 and self.homodyne_arg_2 and gaussian_noise
    
    def translate(self, homodyne_values):        
        # do something with self.translator_arg_1 and self.translator_arg_2 and homodyne_values
```

Similar classes could be defined for different noise models, as long as they have a sample method. I prefer the first, but I can see an argument why some users may prefer this one, since all parameters are agglomerated in a single place. Of course, once a class is defined and a noise object is built, we can use it the same way, no matter how it was built.

### Explicit usage

```python
# Similar to the first example, we define building blocks.
gaussian_noise = GaussianNoise(...) 
homodyne_measurement = HomodyneMeasurement(...) 
translator = CvTranslator(...) 

# However, instead of composing the blocks together, we ask the user to explicitly 
# call each object.

quadratures = gaussian_noise.sample()
homodyne_values = homodyne_measurement.generate_homodyne_values(quadratures)
error = translator.translate(homodyne_values)
code.apply_error(error)
```

This approach is similar to the current version of flamingpy. So, it maybe more familiar to current users. However, I believe the first two solutions make it easier to have predefined and optimised functions for Monte Carlo simulations, since they are always the same. As of today, such function would look like this.

```python
def simulate(code, decoder, noise):
   error = noise.sample()
   code.apply_error(error)
   return correct(code, decoder, ...)
```

However, it will change in the future when more progress is done with the API change.


## Checklist and integration statements

*This is for later when we are done*

- [ ] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 95% or better, and these pass locally for me.
- [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
