### PR TITLE
Added tutorial on macronizing (based on example file)

### DIFF
--- a/doc/tutorials/run_macro_reduce.py
+++ b/doc/tutorials/run_macro_reduce.py
@@ -1,5 +1,5 @@
 r"""
-.. _tutorial_macro_reduce:
+.. _run_macro_reduce:
 Macronodes
 =================================
 

--- a/doc/tutorials/tutorial_macro_reduce.py
+++ b/doc/tutorials/tutorial_macro_reduce.py
@@ -1,13 +1,16 @@
-"""
-Example of simulating Xanadu’s passive and static architecture.
-===============================================================
+r"""
+.. _tutorial_macro_reduce:
+Macronodes
+=================================
 
+*Author: FlamingPy dev team. Last updated: 12 May 2022.*
 """
 
 
 ######################################################################
-# First, we import the relevant modules and functions
-# 
+# First, we import the relevant modules and functions
+
+#
 
 from flamingpy.codes import SurfaceCode
 from flamingpy.cv.ops import CVLayer
@@ -18,9 +21,11 @@ import matplotlib.pyplot as plt
 
 
 ######################################################################
-# Next, we set the number of trials and the code and noise parameters. You
-# are encouraged to play around with these!
-# 
+# Next, we set the number of trials and the code and noise parameters. You
+
+# are encouraged to play around with these!
+
+#
 
 # Code parameters
 d = 3
@@ -37,30 +42,40 @@ RHG_reduced = RHG_code.graph
 
 
 ######################################################################
-# We can generate indices for the nodes (qubits) with ``index_generator``
-# as below. Note that I used ``;`` to suppress the output (this can be
-# pretty large if there are a lot of qubits).
-# 
+# We can generate indices for the nodes (qubits) with ``index_generator``
 
-RHG_reduced.index_generator();
+# as below. Note that I used ``;`` to suppress the output (this can be
+
+# pretty large if there are a lot of qubits).
+
+#
+
+RHG_reduced.index_generator()
 
 
 ######################################################################
-# Let’s draw the lattice to see what it looks like.
-# 
+# Let's draw the lattice to see what it looks like.
+
+#
 
 RHG_reduced.draw()
 plt.show()
 
 
 ######################################################################
-# From the “reduced” RHG lattice, we can generated a so-called macronized
-# version of it, see `this
-# paper <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353>`__
-# for more details. Essentially, we replace every node with 4 nodes. This
-# is particularly useful, because it allows for a physical implementation
-# with **static** optics!
-# 
+# From the reduced RHG lattice, we can generated a so-called macronized
+
+# version of it, see `this
+
+# paper <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353>`__
+
+# for more details. Essentially, we replace every node with 4 nodes. This
+
+# is particularly useful, because it allows for a physical implementation
+
+# with **static** optics!
+
+#
 
 # The lattice with macronodes
 pad_bool = boundaries != "periodic"
@@ -73,9 +88,11 @@ plt.show()
 
 
 ######################################################################
-# As you can see, we replaced every node with a group of four nodes,
-# sweet!
-# 
+# As you can see, we replaced every node with a group of four nodes,
+
+# sweet!
+
+#
 
 # The empty CV layer, uninitiated with any error model.
 CVRHG_reduced = CVLayer(RHG_code)
@@ -86,9 +103,11 @@ bs_network = BS_network(4)
 
 
 ######################################################################
-# Let’s see how well our encoding works. To do so, we run a simulation
-# ``n_trials``, and see how many times we corrected it truthfully.
-# 
+# Let's see how well our encoding works. To do so, we run a simulation
+
+# ``n_trials``, and see how many times we corrected it truthfully.
+
+#
 
 # Number of trials
 n_trials = 100
@@ -98,16 +117,16 @@ successes = 0
 for trial in range(n_trials):
     # The empty CV state, uninitiated with any error model.
     reduce_macro_and_simulate(RHG_macro, RHG_reduced, CVRHG_reduced, bs_network, p_swap, delta)
-    
+
     weight_options = {
         "method": "blueprint",
         "prob_precomputed": True,
     }
-    
+
     decoder = {"outer": "MWPM"}
-    
+
     c = correct(code=RHG_code, decoder=decoder, weight_options=weight_options)
-    
+
     successes += int(c)
 
 # Results

--- a/doc/tutorials/tutorial_macro_reduce.py
+++ b/doc/tutorials/tutorial_macro_reduce.py
@@ -9,7 +9,7 @@ Macronodes
 
 ######################################################################
 # First, we import the relevant modules and functions
-
+#
 #
 
 from flamingpy.codes import SurfaceCode
@@ -22,9 +22,7 @@ import matplotlib.pyplot as plt
 
 ######################################################################
 # Next, we set the number of trials and the code and noise parameters. You
-
 # are encouraged to play around with these!
-
 #
 
 # Code parameters
@@ -43,11 +41,9 @@ RHG_reduced = RHG_code.graph
 
 ######################################################################
 # We can generate indices for the nodes (qubits) with ``index_generator``
-
 # as below. Note that I used ``;`` to suppress the output (this can be
-
 # pretty large if there are a lot of qubits).
-
+#
 #
 
 RHG_reduced.index_generator()
@@ -55,7 +51,7 @@ RHG_reduced.index_generator()
 
 ######################################################################
 # Let's draw the lattice to see what it looks like.
-
+#
 #
 
 RHG_reduced.draw()
@@ -64,17 +60,11 @@ plt.show()
 
 ######################################################################
 # From the reduced RHG lattice, we can generated a so-called macronized
-
 # version of it, see `this
-
 # paper <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353>`__
-
 # for more details. Essentially, we replace every node with 4 nodes. This
-
 # is particularly useful, because it allows for a physical implementation
-
 # with **static** optics!
-
 #
 
 # The lattice with macronodes
@@ -89,9 +79,7 @@ plt.show()
 
 ######################################################################
 # As you can see, we replaced every node with a group of four nodes,
-
 # sweet!
-
 #
 
 # The empty CV layer, uninitiated with any error model.
@@ -104,9 +92,8 @@ bs_network = BS_network(4)
 
 ######################################################################
 # Let's see how well our encoding works. To do so, we run a simulation
-
+#
 # ``n_trials``, and see how many times we corrected it truthfully.
-
 #
 
 # Number of trials

--- a/doc/tutorials/tutorial_macro_reduce.py
+++ b/doc/tutorials/tutorial_macro_reduce.py
@@ -1,0 +1,117 @@
+"""
+Example of simulating Xanadu’s passive and static architecture.
+===============================================================
+
+"""
+
+
+######################################################################
+# First, we import the relevant modules and functions
+# 
+
+from flamingpy.codes import SurfaceCode
+from flamingpy.cv.ops import CVLayer
+from flamingpy.cv.macro_reduce import BS_network, reduce_macro_and_simulate
+from flamingpy.decoders.decoder import correct
+
+import matplotlib.pyplot as plt
+
+
+######################################################################
+# Next, we set the number of trials and the code and noise parameters. You
+# are encouraged to play around with these!
+# 
+
+# Code parameters
+d = 3
+boundaries = "open"
+ec = "primal"
+
+# Noise parameters
+delta = 0.1
+p_swap = 0.4
+
+# The reduced lattice.
+RHG_code = SurfaceCode(d, ec=ec, boundaries=boundaries)
+RHG_reduced = RHG_code.graph
+
+
+######################################################################
+# We can generate indices for the nodes (qubits) with ``index_generator``
+# as below. Note that I used ``;`` to suppress the output (this can be
+# pretty large if there are a lot of qubits).
+# 
+
+RHG_reduced.index_generator();
+
+
+######################################################################
+# Let’s draw the lattice to see what it looks like.
+# 
+
+RHG_reduced.draw()
+plt.show()
+
+
+######################################################################
+# From the “reduced” RHG lattice, we can generated a so-called macronized
+# version of it, see `this
+# paper <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353>`__
+# for more details. Essentially, we replace every node with 4 nodes. This
+# is particularly useful, because it allows for a physical implementation
+# with **static** optics!
+# 
+
+# The lattice with macronodes
+pad_bool = boundaries != "periodic"
+RHG_macro = RHG_code.graph.macronize(pad_boundary=pad_bool)
+RHG_macro.index_generator()
+RHG_macro.adj_generator(sparse=True)
+
+RHG_macro.draw()
+plt.show()
+
+
+######################################################################
+# As you can see, we replaced every node with a group of four nodes,
+# sweet!
+# 
+
+# The empty CV layer, uninitiated with any error model.
+CVRHG_reduced = CVLayer(RHG_code)
+
+# Define the 4X4 beamsplitter network for a given macronode.
+# star at index 0, planets at indices 1-3.
+bs_network = BS_network(4)
+
+
+######################################################################
+# Let’s see how well our encoding works. To do so, we run a simulation
+# ``n_trials``, and see how many times we corrected it truthfully.
+# 
+
+# Number of trials
+n_trials = 100
+
+# Simulation
+successes = 0
+for trial in range(n_trials):
+    # The empty CV state, uninitiated with any error model.
+    reduce_macro_and_simulate(RHG_macro, RHG_reduced, CVRHG_reduced, bs_network, p_swap, delta)
+    
+    weight_options = {
+        "method": "blueprint",
+        "prob_precomputed": True,
+    }
+    
+    decoder = {"outer": "MWPM"}
+    
+    c = correct(code=RHG_code, decoder=decoder, weight_options=weight_options)
+    
+    successes += int(c)
+
+# Results
+error = (n_trials - successes) / n_trials
+print("Trials: ", n_trials)
+print("Successes: ", successes)
+print("Error rate: ", error)

--- a/doc/tutorials/tutorial_macro_reduce.py
+++ b/doc/tutorials/tutorial_macro_reduce.py
@@ -40,7 +40,7 @@ RHG_reduced = RHG_code.graph
 
 
 ######################################################################
-# We can generate indices for the nodes (qubits) with ``index_generator``
+# We can generate indices for the nodes with ``index_generator``
 # as below. Note that I used ``;`` to suppress the output (this can be
 # pretty large if there are a lot of qubits).
 #
@@ -60,11 +60,9 @@ plt.show()
 
 ######################################################################
 # From the reduced RHG lattice, we can generated a so-called macronized
-# version of it, see `this
-# paper <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353>`__
-# for more details. Essentially, we replace every node with 4 nodes. This
-# is particularly useful, because it allows for a physical implementation
-# with **static** optics!
+# version of it, see [this paper](https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.040353)
+# for more details. Essentially, we replace every node with 4 nodes. This is particularly useful,
+# because it allows for a physical implementation with _static optics_!
 #
 
 # The lattice with macronodes
@@ -92,7 +90,6 @@ bs_network = BS_network(4)
 
 ######################################################################
 # Let's see how well our encoding works. To do so, we run a simulation
-#
 # ``n_trials``, and see how many times we corrected it truthfully.
 #
 
@@ -118,6 +115,7 @@ for trial in range(n_trials):
 
 # Results
 error = (n_trials - successes) / n_trials
+
 print("Trials: ", n_trials)
 print("Successes: ", successes)
 print("Error rate: ", error)

--- a/doc/tutorials/tutorial_macro_reduce.py
+++ b/doc/tutorials/tutorial_macro_reduce.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 
 
 ######################################################################
-# Next, we set the number of trials and the code and noise parameters. You
+# Next, we set the code and noise parameters. You
 # are encouraged to play around with these!
 #
 

--- a/doc/usage/tutorials.rst
+++ b/doc/usage/tutorials.rst
@@ -35,4 +35,9 @@ FlamingPy tutorials.
     :figure: tutorials/_out/images/thumb/sphx_glr_run_graph_states_thumb.png
     :description: :doc:`../tutorials/_out/run_graph_states`
 
+.. gallery-item::
+    :tooltip: Macronode tutorial.
+    :figure: tutorials/_out/images/thumb/sphx_glr_run_graph_states_thumb.png
+    :description: :doc:`../tutorials/_out/tutorial_macro_reduce`
+
 :html:`</div></div><div style='clear:both'>`

--- a/doc/usage/tutorials.rst
+++ b/doc/usage/tutorials.rst
@@ -37,7 +37,7 @@ FlamingPy tutorials.
 
 .. gallery-item::
     :tooltip: Macronode tutorial.
-    :figure: tutorials/_out/images/thumb/sphx_glr_run_graph_states_thumb.png
-    :description: :doc:`../tutorials/_out/tutorial_macro_reduce`
+    :figure: tutorials/_out/images/thumb/sphx_glr_run_macro_reduce_thumb.png
+    :description: :doc:`../tutorials/_out/run_macro_reduce`
 
 :html:`</div></div><div style='clear:both'>`


### PR DESCRIPTION
## Context for changes

Hey @sduquemesa , I was working through the examples folder with jupy notebooks, and figured I might as well convert the one I made for `macro_reduce.py` in a tutorial. I annotated the code a bit but could use some upgrade/elaboration at some point.

- **New features**:
    * New tutorial on macronization