### PR TITLE
Splitting the correction from finding the recovery set

### DIFF
--- a/flamingpy/decoders/decoder.py
+++ b/flamingpy/decoders/decoder.py
@@ -322,3 +322,6 @@ def correct(
     if sanity_check:
         return np.all(result[0])
     return np.all(result)
+
+def find_recovery_set():
+    pass


### PR DESCRIPTION
## Context for changes
This PR is aimed to split the correction operation from the operation finding the recovery set. The "heavy" `correction` method is thus [split into two methods](https://github.com/XanaduAI/flamingpy/issues/54#issuecomment-1137358565). This allows for more flexibility and it should also fix #54.

- **Improvements**: 
    * `correction` method of the decoding is split into two
    * Decoding operation can be drawn without running correction prior to it, see #54 
- **Documentation changes**:
    * Updates relevant docstrings

## Example usage and tests

< Add some example usage and tests showing how to utilize new features and fixes; otherwise, mark N/A below. >
- [ ] Not Applicable


## Performance results justifying changes

< If you have improved a feature you should support it with some benchmarking and scaling results, plots, etc.; otherwise, mark N/A below. >
- [ ] Not Applicable

## Workflow actions and tests

< In most cases, we need a set of unit tests that automatically and comprehensively test for newly added features. Discuss existing CI tests that cover the changes or any updates to the workflow here; otherwise, mark N/A below. >

- [ ] Not Applicable


## Expected benefits and drawbacks

< Summarize your justifications for the change and its benefits. Is there any drawback that exists today with the changes or may occur in the future? You cannot place N/A here. >

**Expected benefits:**
- < text goes here >

**Possible drawbacks:**
- < text goes here >

## Related Github issues

< Explicitly, link any corresponding issue and update the status of the relevant GitHub issue here; otherwise, mark N/A below. >
- [ ] Not Applicable

## Checklist and integration statements

- [ ] My Python and C++ codes follow the coding and commenting styles of this project as indicated by existing files. Specifically, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage 95% or better, and these pass locally for me.
- [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
