### PR TITLE
Remove unused pandas

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### New features since the last release
 
-* Node and edge coloring can now be done based on any attribute and personalized colors can be defined via a dictionary: [#32](https://github.com/XanaduAI/flamingpy/pull/32)(backward compatible) 
+* Node and edge coloring can now be done based on any attribute and personalized colors can be defined via a dictionary: [#32](https://github.com/XanaduAI/flamingpy/pull/32)(backward compatible)
  * The `EGraph` plot legend is not limited to the "state" attribute of the node but to any attribute.
 * The `dims` attribute of `EGraph` has been removed. Its function is replaced by the `dimensions` parameter that is passed to the `draw_EGraph` method. This method does not require the `EGraph` to have a `dims` attribute defined anymore. [#42](https://github.com/XanaduAI/flamingpy/pull/42)(backward incompatible)
 * Our frontend simulator script, [`simulations.py`](flamingpy/simulations.py), now supports simple and highly-scalable MPI jobs through `mpi4py` libraries in a non-intrusive manner. The users who do **not** have or want MPI, can run `simulations.py` single-threaded as per usual without facing any errors. MPI users can speed up Monte Carlo samplings in EC steps virtually up to as many processors they can throw at it. The script support jobs both on local machines and large-scale clusters.
  MPI users on their local machines can simply run the following for a 4-processor job:
- `mpirun -np 4 python flamingpy/simulations.py` [#47](https://github.com/XanaduAI/flamingpy/pull/47)(backward compatible) 
+ `mpirun -np 4 python flamingpy/simulations.py` [#47](https://github.com/XanaduAI/flamingpy/pull/47)(backward compatible)
 
 ### Bug fixes
 * Fixed the class inheretance diagram displayed in `fp.codes`. [#41](https://github.com/XanaduAI/flamingpy/pull/41)
@@ -24,7 +24,8 @@
  * `display_axes` is changed to `show_axes` for consistency.
 * `xlim` in `viz.plot_Z_err_cond` is adjusted to the relevant domain when plotting the central peak. [#33](https://github.com/XanaduAI/flamingpy/pull/33)
 * Added `fig, ax` returns for the draw methods in `utils/viz.py`. [#33](https://github.com/XanaduAI/flamingpy/pull/33)
-* Both upper and lower axes limits can now be specified for `EGraph` plots. [#42](https://github.com/XanaduAI/flamingpy/pull/42) 
+* Both upper and lower axes limits can now be specified for `EGraph` plots. [#42](https://github.com/XanaduAI/flamingpy/pull/42)
+* Pandas is removed from the package requirements. [#63](https://github.com/XanaduAI/flamingpy/pull/63)
 
 ### Documentation changes
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,6 @@ ignore-patterns=doc/tutorials/*
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
 ignored-modules=numpy,scipy,networkx,retworkx
-generated-members=pandas
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,7 +7,6 @@ matplotlib>=3.3.3
 mpi4py>=3.1.3; sys_platform == 'linux'
 networkx>=2.5
 numpy>=1.21
-pandas>=1.2.1
 pytest>=6.2
 pytest-cov>=3.0
 pytest-logger>=0.5.1

--- a/doc/build_docs.rst
+++ b/doc/build_docs.rst
@@ -9,7 +9,6 @@ The FlamingPy documentation is built using `sphinx`. To build the documentation 
 * `networkx <https://networkx.org/>`_ >= 2.5
 * `numba <https://numba.pydata.org/>`_ >= 0.53.1
 * `NumPy <http://numpy.org/>`_ >= 1.21.0
-* `pandas <https://pandas.pydata.org/>`_ >= 1.2.1
 * `pylint <https://pypi.org/project/pylint/>`_ >= 2.13.9
 * `retworkx <https://qiskit.org/documentation/retworkx/>`_ >= 0.10.2
 * `scipy <https://scipy.org/>`_ >= 1.6.0
@@ -31,6 +30,6 @@ We will build the documentation using `make` (if you require to install and unde
 
   $ make html
 
-You may need to run ``make clean`` beforehand. 
+You may need to run ``make clean`` beforehand.
 
 The documentation can be found in the :file:`doc/_build/html/` directory.

--- a/doc/dev_requirements.txt
+++ b/doc/dev_requirements.txt
@@ -4,7 +4,6 @@ matplotlib>=3.3.3
 networkx>=2.5
 numba>=0.53.1
 numpy>=1.21
-pandas>=1.2.1
 pylint>=2.13.9
 retworkx>=0.10.2
 scipy>=1.6

--- a/doc/development/guide_for_devs.rst
+++ b/doc/development/guide_for_devs.rst
@@ -19,7 +19,6 @@ as well as the following Python packages for development purposes:
 * `mpi4py <https://mpi4py.readthedocs.io/en/stable/>`_ >= 3.1.3 (required only for Linux users)
 * `networkx <https://networkx.org/>`_ >= 2.5
 * `NumPy <http://numpy.org/>`_ >= 1.21
-* `pandas <https://pandas.pydata.org/>`_ >= 1.2.1
 * `pytest <https://docs.pytest.org/en/7.1.x/>`_ >= 6.2
 * `pytest-cov <https://pypi.org/project/pytest-cov/>`_ >= 3.0
 * `pytest-logger <https://pypi.org/project/pytest-logger/>`_ >= 0.5.1
@@ -35,10 +34,10 @@ of Python packaged for scientific computation.
 Setting up a development environment
 ------------------------------------
 
-If you are a developer and wish to manipulate and test FlamingPy source code, you need 
-to set up a development environment. First, clone the FlamingPy repository. 
-Then, create and activate a new virtual environment (if you prefer using an existing 
-environment, you may need to uninstall existing FlamingPy builds). If you use **Conda**, 
+If you are a developer and wish to manipulate and test FlamingPy source code, you need
+to set up a development environment. First, clone the FlamingPy repository.
+Then, create and activate a new virtual environment (if you prefer using an existing
+environment, you may need to uninstall existing FlamingPy builds). If you use **Conda**,
 for example, you may run the following:
 
 .. code-block:: bash
@@ -46,7 +45,7 @@ for example, you may run the following:
     conda create -n flamingpy python=3.8
     conda activate flamingpy
 
-FlamingPy uses a ``pytest`` suite for testing and ``pytest-cov`` for code coverage. These dependencies among compilation 
+FlamingPy uses a ``pytest`` suite for testing and ``pytest-cov`` for code coverage. These dependencies among compilation
 and other requirements as stated in the above section can be installed via ``pip``:
 
 .. code-block:: bash
@@ -62,18 +61,18 @@ To install FlamingPy from Source, next change to the directory where FlamingPy w
 
     python setup.py develop # only installs Python libraries
     python setup.py build_cython --inplace # [OPTIONAL] compiles Cython-based backends
-    python setup.py build_cmake --inplace # [OPTIONAL] compiles CMake-based backends 
+    python setup.py build_cmake --inplace # [OPTIONAL] compiles CMake-based backends
 
 The purpose of the commands is as follows:
 
-* The first command installs dependencies for building the project and testing purposes, and can be skipped if already satisfied. 
-* The second command (develop) installs FlamingPy Python libraries without compiling the optional backends. 
-* The next optional commands compile various FlamingPy backends as required (given you have appropriate compilers pre-installed). 
+* The first command installs dependencies for building the project and testing purposes, and can be skipped if already satisfied.
+* The second command (develop) installs FlamingPy Python libraries without compiling the optional backends.
+* The next optional commands compile various FlamingPy backends as required (given you have appropriate compilers pre-installed).
 
-If you encountered a CMake error, you may need to (re-)install it through 
-`conda install cmake` or other means before re-attempting the above. Furthermore, 
-you may wish to try `conda install git`. For more detailed instructions and 
-recommendations, including how to configure your environments, compilers and 
+If you encountered a CMake error, you may need to (re-)install it through
+`conda install cmake` or other means before re-attempting the above. Furthermore,
+you may wish to try `conda install git`. For more detailed instructions and
+recommendations, including how to configure your environments, compilers and
 resolve errors, see our Frequently Encountered Errors page.
 
 Software tests
@@ -120,6 +119,6 @@ from the `doc` directory to then build the HTML documentation, run
 
     make html
 
-You may need to run ``make clean`` beforehand. 
+You may need to run ``make clean`` beforehand.
 
 The documentation can be found in the :file:`doc/_build/html/` directory.

--- a/flamingpy/__init__.py
+++ b/flamingpy/__init__.py
@@ -24,7 +24,6 @@ import scipy
 import networkx
 import retworkx
 import matplotlib
-import pandas
 
 try:
     import flamingpy.cpp.lemonpy as lp
@@ -70,6 +69,5 @@ def about():
     print("NetworkX version:            {}".format(networkx.__version__))
     print("RetworkX version:            {}".format(retworkx.__version__))
     print("Matplotlib version:          {}".format(matplotlib.__version__))
-    print("Pandas version:              {}".format(pandas.__version__))
     print("lemonpy shared object:       {}".format(lp))
     print("cpp_mc_loop shared object:   {}".format(cmc))

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -15,4 +15,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.7.0a4.dev7"
+__version__ = "0.7.0a4.dev8"


### PR DESCRIPTION
## Context for changes

Pandas is not used in the codebase

- **Improvements**: 
    * Removes `pandas` as a dependency of the package
- **Documentation changes**:
    * Removes any reference to `pandas`

## Example usage and tests

- [x] Not Applicable


## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable

## Expected benefits and drawbacks

**Expected benefits:**
- Less dependencies

**Possible drawbacks:**
- None

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.

- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
