### PR TITLE
Use pylint stable version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 
 ### Improvements
-- Pylint is pinned to stable version `pylint==2.14.0` and added to `dev_requirements.txt`. [#76](https://github.com/XanaduAI/flamingpy/pull/76)
+* Pylint is pinned to stable version `pylint==2.14.0` and added to `dev_requirements.txt`. [#76](https://github.com/XanaduAI/flamingpy/pull/76)
+ * pylint no-self-use tags are removed as this check has been removed from pylint (see [here](https://github.com/PyCQA/pylint/issues/5502)). 
 
 ### Documentation changes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 
 ### Improvements
-
+- Pylint is pinned to stable version `pylint==2.14.0` and added to `dev_requirements.txt`. [#76](https://github.com/XanaduAI/flamingpy/pull/76)
 
 ### Documentation changes
 
@@ -15,6 +15,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Sebastián Duque Mesa](https://github.com/sduquemesa)
 
 See full commit details ...
 

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get the latest pip and pylint
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pylint
+          python3 -m pip install pylint==2.14.0
 
       - uses: actions/checkout@v2
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -14,3 +14,4 @@ retworkx>=0.10.2
 setuptools>=62.3.2
 scipy>=1.6
 thewalrus>=0.19.0
+pylint==2.14.0

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -15,4 +15,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.8.2a5"
+__version__ = "0.8.2a5-dev0"

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """"Unit tests for MWPM and decoding funcions in the decoder module."""
 
-# pylint: disable=no-member,protected-access,no-self-use
+# pylint: disable=no-member,protected-access
 
 import itertools as it
 

--- a/tests/unit/test_gkp.py
+++ b/tests/unit/test_gkp.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """"Unit tests for GKP-specific functions in the GKP module."""
 
-# pylint: disable=no-self-use
 
 import numpy as np
 from numpy import sqrt, pi

--- a/tests/unit/test_graphstates.py
+++ b/tests/unit/test_graphstates.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """"Unit tests for the graph state classes in the graphstates module."""
 
-# pylint: disable=protected-access,no-self-use
+# pylint: disable=protected-access
 
 import string
 

--- a/tests/unit/test_macro_reduce.py
+++ b/tests/unit/test_macro_reduce.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Unit tests for passive_construct module members."""
 
-# pylint: disable=no-self-use
 
 import itertools as it
 

--- a/tests/unit/test_simulations.py
+++ b/tests/unit/test_simulations.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Unit tests for Monte Carlo simulations for estimating FT thresholds."""
 
-# pylint: disable=no-self-use,protected-access,too-few-public-methods
+# pylint: disable=protected-access,too-few-public-methods
 
 import warnings
 

--- a/tests/unit/test_surface_code.py
+++ b/tests/unit/test_surface_code.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """"Unit tests for classes and methods in the surface_code module."""
 
-# pylint: disable=no-self-use,too-few-public-methods
+# pylint: disable=too-few-public-methods
 
 import itertools as it
 

--- a/tests/unit/test_surface_code.py
+++ b/tests/unit/test_surface_code.py
@@ -120,8 +120,9 @@ def RHG_graph_old(dims, boundaries="finite", macronodes=False, polarity=False):
         """Coordinates of all potential neighbours of green vertices."""
         return [(p[0], p[1], p[2] - displace), (p[0], p[1], p[2] + displace)]
 
-    # Polarity-dependent color function: blue for +1, red for -1.
-    color = lambda pol: ((pol + 1) // 2) * "b" + abs((pol - 1) // 2) * "r"
+    def color(pol):
+        """Polarity-dependent color function: blue for +1, red for -1."""
+        return ((pol + 1) // 2) * "b" + abs((pol - 1) // 2) * "r"
 
     if macronodes:
         lattice.macro_to_micro = {}

--- a/tests/unit/test_uf_decoder.py
+++ b/tests/unit/test_uf_decoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """"Unit tests for the Union Find decoder."""
 
-# pylint: disable=too-many-function-args,no-self-use,unsubscriptable-object,consider-using-dict-items,too-few-public-methods,too-many-locals,unused-argument,pointless-statement
+# pylint: disable=too-many-function-args,unsubscriptable-object,consider-using-dict-items,too-few-public-methods,too-many-locals,unused-argument,pointless-statement
 
 import itertools as it
 import random


### PR DESCRIPTION
## Context for changes

CI checks use pylint latest. With the [new release](https://github.com/PyCQA/pylint/releases/tag/v3.0.0-a5) breaking changes have been added.

This PR also removes pylint tags `no-self-use` as this checker has been removed from pylint. See [here](https://github.com/PyCQA/pylint/issues/5502). 

## Example usage and tests

- [x] Not Applicable

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

Pylint is pinned to stable version `pylint==2.14.0`

## Expected benefits and drawbacks

**Expected benefits:**
- CI checks won't fail from newly introduced breaking changes to pylint

**Possible drawbacks:**
- None. Just keep an eye to new stable releases of pylint.

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
