### PR TITLE
[unitaryhack] EGraph visualizations using Plotly 🎨

### DIFF
--- a/flamingpy/codes/graphs/egraph.py
+++ b/flamingpy/codes/graphs/egraph.py
@@ -205,8 +205,13 @@ class EGraph(nx.Graph):
         _, ax = draw_EGraph(self, **kwargs)
         return ax
     
-    def draw_3DScatterPlot(self,**kwargs):
+    def draw_3D(self,**kwargs):
+        """Draw the graph state with Plotly Express.
+
+        See flamingpy.utils.viz.draw_EGraph_3DScatterPlot for more details.
+        """
         from flamingpy.utils.viz import draw_EGraph_3DScatterPlot
+        
         fig = draw_EGraph_3DScatterPlot(self,**kwargs)
         return fig
         

--- a/flamingpy/codes/graphs/egraph.py
+++ b/flamingpy/codes/graphs/egraph.py
@@ -204,6 +204,12 @@ class EGraph(nx.Graph):
 
         _, ax = draw_EGraph(self, **kwargs)
         return ax
+    
+    def draw_3DScatterPlot(self,**kwargs):
+        from flamingpy.utils.viz import draw_EGraph_3DScatterPlot
+        fig = draw_EGraph_3DScatterPlot(self,**kwargs)
+        return fig
+        
 
     def draw_adj(self, **kwargs):
         """Draw the adjacency matrix with matplotlib.

--- a/flamingpy/codes/surface_code.py
+++ b/flamingpy/codes/surface_code.py
@@ -482,6 +482,24 @@ class SurfaceCode:
         }
         updated_opts = {**default_opts, **kwargs}
         return self.graph.draw(**updated_opts)
+    
+    def draw_3D(self, **kwargs):
+        """Draw the cluster with Plotly Express.
+
+        See ``flamingpy.utils.viz.draw_EGraph_3DScatterPlot`` for more details. Use
+        the default colour options: black for primal nodes, grey for dual nodes;
+        blue for weight +1 edges, red for weight -1 edges.
+        """
+        edge_colors = "grey"
+        if self.polarity is not None:
+            if self.polarity.__name__ == "alternating_polarity":
+                edge_colors = ("weight", {1: "b", -1: "r"})
+        default_opts = {
+            "color_nodes": ("type", {"primal": "black", "dual": "grey"}),
+            "color_edges": edge_colors,
+        }
+        updated_opts = {**default_opts, **kwargs}
+        return self.graph.draw_3D(**updated_opts)
 
     def draw_stabilizer_graph(self, ec, **kwargs):
         """Draw the stabilizer graph with matplotlib.

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -296,6 +296,60 @@ def draw_EGraph_3DScatterPlot(
     show_axes=True,
     dimensions=None,
 ):
+"""Draw the graph state represented by the EGraph.
+
+    Args:
+        color_nodes (bool or string or dict): Options are:
+            True: color the nodes based on the 'color' attribute
+            attached to the node. If unavailable, color nodes black.
+
+            string: color all nodes with the color specified by the string
+
+            tuple[str, dict]: color nodes based on attribute and defined colour
+            string by providing a tuple with [attribute, color_dictionary],
+            for example:
+
+                ``["state", {"GKP": "b", "p": "r"}]``
+
+            will look at the "state" attribute of the node, and colour
+            according to the dictionary.
+
+        color_edges (bool or string or dict):
+            True: color the edges based on the 'color' attribute
+            attached to the node. If unavailable, color nodes grey.
+
+            string: color all edges with the color specified by the stirng
+
+            tuple: color edges based on attribute and defined colour
+            string by providing a tuple with [attribute, color_dictionary],
+            for example: if the edge attribute "weight" can be +1 or -1,
+            the tuple should be of the form:
+
+                ``("weight", {-1: minus_color, +1: plus_color})``
+
+        label (NoneType or string): plot values next to each node
+            associated with the node attribute label. For example,
+            to plot bit values, set label to "bit_val". If set to 'index',
+            it will plot the integer indices of the nodes. If the attribute
+            for some or all of the nodes, a message will print indicating
+            for how many nodes the attribute has not been set.
+        title (bool): if True, display the title, depending on the label.
+            For default labels, the titles are converted from attribute
+            name to plane English and capitalized.
+        legend (bool): if True and color_nodes argument is a tuple(str, dict),
+            display the a color legend with node attributes.
+        show_axes (bool): if False, turn off the axes.
+        dimensions (tuple): Dimensions of the region that should be plotted.
+            Should be of the form:
+
+                ``([xmin, xmax], [ymin, ymax], [zmin, zmax])``
+
+            If None, sets the dimensions to the smallest rectangular space
+            containing all the nodes.
+
+    Returns:
+        figure: Plotly Express figure.
+    """
     egraph_3D = nx.spring_layout(egraph,dim=3, seed=18)
     Num_nodes = egraph.number_of_nodes()
     node_list = list(egraph)

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -33,6 +33,7 @@ import math
 
 import numpy as np
 import networkx as nx
+import plotly.graph_objects as go
 import matplotlib as mpl
 from matplotlib.patches import Patch
 from matplotlib.ticker import Formatter
@@ -283,6 +284,84 @@ def draw_EGraph(
     plt.draw()
 
     return fig, ax
+
+@mpl.rc_context(plot_params)
+def draw_EGraph_3DScatterPlot(
+    egraph,
+    color_nodes=False,
+    color_edges=False,
+    label=None,
+    title=False,
+    legend=False,
+    show_axes=True,
+    dimensions=None,
+):
+    egraph_3D = nx.spring_layout(egraph,dim=3, seed=18)
+    print(egraph_3D)
+    Num_nodes = egraph.number_of_nodes();
+    #print(Num_nodes)
+    node_list = list(egraph)
+    x_nodes = [egraph_3D[node_list[i]][0] for i in range(Num_nodes)]# x-coordinates of nodes
+    y_nodes = [egraph_3D[node_list[i]][1] for i in range(Num_nodes)]# y-coordinates
+    z_nodes = [egraph_3D[node_list[i]][0] for i in range(Num_nodes)]# z-coordinates
+    edge_list = list(egraph.edges())
+
+    x_edges=[]
+    y_edges=[]
+    z_edges=[]
+
+    for edge in edge_list:
+    #format: [beginning,ending,None]
+        x_coords = [egraph_3D[edge[0]][0],egraph_3D[edge[1]][0],None]
+        x_edges += x_coords
+
+        y_coords = [egraph_3D[edge[0]][1],egraph_3D[edge[1]][1],None]
+        y_edges += y_coords
+
+        z_coords = [egraph_3D[edge[0]][2],egraph_3D[edge[1]][2],None]
+        z_edges += z_coords
+    nodeColors = []
+    for point in egraph.nodes:
+        x,y,z = point
+        color = _get_node_color(egraph, color_nodes, point)
+        nodeColors.append(color)
+    trace_edges = go.Scatter3d(x=x_edges,
+                        y=y_edges,
+                        z=z_edges,
+                        mode='lines',
+                        line=dict(color='black', width=2),
+                        hoverinfo='none')
+    #create a trace for the nodes
+    trace_nodes = go.Scatter3d(x=x_nodes,
+                         y=y_nodes,
+                        z=z_nodes,
+                        mode='markers',
+                        marker=dict(symbol='circle',
+                                    size=5,
+                                    color = nodeColors,
+                                    colorscale=['lightgreen','magenta'], #either green or mageneta
+                                    line=dict(color='black', width=0.5)),
+                        text=["abc","cde","def"],
+                        hoverinfo='text')
+    axis = dict(showbackground=True,
+            showline=True,
+            zeroline=False,
+            showgrid=True,
+            showticklabels=False,
+            title='')
+    layout = go.Layout(title="XXX",
+                width=650,
+                height=625,
+                showlegend=True,
+                scene=dict(xaxis=dict(axis),
+                        yaxis=dict(axis),
+                        zaxis=dict(axis),
+                        ),
+                margin=dict(t=100),
+                hovermode='closest')
+    data = [trace_edges, trace_nodes]
+    fig = go.Figure(data=data, layout=layout)
+    return fig
 
 
 def _plot_EGraph_edges(ax, egraph, color_edges):

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -297,9 +297,7 @@ def draw_EGraph_3DScatterPlot(
     dimensions=None,
 ):
     egraph_3D = nx.spring_layout(egraph,dim=3, seed=18)
-    print(egraph_3D)
-    Num_nodes = egraph.number_of_nodes();
-    #print(Num_nodes)
+    Num_nodes = egraph.number_of_nodes()
     node_list = list(egraph)
     x_nodes = [egraph_3D[node_list[i]][0] for i in range(Num_nodes)]# x-coordinates of nodes
     y_nodes = [egraph_3D[node_list[i]][1] for i in range(Num_nodes)]# y-coordinates
@@ -341,21 +339,23 @@ def draw_EGraph_3DScatterPlot(
                                     color = nodeColors,
                                     colorscale=['lightgreen','magenta'], #either green or mageneta
                                     line=dict(color='black', width=0.5)),
-                        text=["abc","cde","def"],
-                        hoverinfo='text')
+                        hoverinfo='none')
     axis = dict(showbackground=True,
             showline=True,
             zeroline=False,
             showgrid=True,
             showticklabels=False,
             title='')
-    layout = go.Layout(title="XXX",
+    layout = go.Layout(title='',
                 width=650,
                 height=625,
-                showlegend=True,
+                showlegend=legend,
                 scene=dict(xaxis=dict(axis),
                         yaxis=dict(axis),
                         zaxis=dict(axis),
+                        xaxis_title='X',
+                        yaxis_title='Y',
+                        zaxis_title='Z',
                         ),
                 margin=dict(t=100),
                 hovermode='closest')
@@ -512,9 +512,9 @@ def _get_node_color(egraph, color_nodes, point):
         color = color_dict.get(node_property)
 
     elif color_nodes == True:
-        color = egraph.nodes[point].get("color") or "k"
+        color = egraph.nodes[point].get("color") or "black"
     else:
-        color = "k"
+        color = "black"
     return color
 
 


### PR DESCRIPTION
## Context for changes

A better and more interactive way to visualize graph states.

- **New features**:
    * 3D plot visualization of graph states using Plotly Express
- **Bug fixes**: 
    * Replaced the 'k' value denoting black color to 'Black', which is accepted by both Plotly and Matplotlib
- **Improvements**: 
    * Better 3d interactivity with plots in comparison to Matplotlib
- **Documentation changes**:
    * A new function in Egraph.py
    * A new function in viz.py
    * A new function in surface_code.py

## Example usage and tests

- Example 1
```
from flamingpy.codes import SurfaceCode
from flamingpy.codes.graphs import EGraph
code = SurfaceCode(2)
code.draw_3D()
```
![ezgif-3-becd30174c](https://user-images.githubusercontent.com/41890388/174137327-a8f87c80-ab39-49a4-a843-7eeffd35d149.gif)


## Performance results justifying changes

< If you have improved a feature you should support it with some benchmarking and scaling results, plots, etc.; otherwise, mark N/A below. >
- [ ] to be updated...

## Workflow actions and tests

< In most cases, we need a set of unit tests that automatically and comprehensively test for newly added features. Discuss existing CI tests that cover the changes or any updates to the workflow here; otherwise, mark N/A below. >

- [ ] to be updated...


## Expected benefits and drawbacks

< Summarize your justifications for the change and its benefits. Is there any drawback that exists today with the changes or may occur in the future? You cannot place N/A here. >

**Expected benefits:**
- Better interactivity with graph states

**Possible drawbacks:**
- < text goes here >

## Related Github issues
- closes #72

## Checklist and integration statements

- [ ] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations. 
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.

- [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
