### PR TITLE
[Hotfix] Correct an error in the initial sampling of CVLayer

### DIFF
--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.8.2a5.dev11"
+__version__ = "0.8.2a5.dev12"

--- a/flamingpy/noise/cv.py
+++ b/flamingpy/noise/cv.py
@@ -205,7 +205,7 @@ class CVLayer:
 
         # For the initial sampling order, entangle the samples
         if self._sampling_order == "initial":
-            outcomes = SCZ_apply(self._adj, covs)
+            outcomes = SCZ_apply(self._adj, outcomes)
             if quad == "q":
                 outcomes = outcomes[:N][inds]
             elif quad == "p":

--- a/tests/qubit_codes/test_stabilizer_graph.py
+++ b/tests/qubit_codes/test_stabilizer_graph.py
@@ -83,8 +83,7 @@ def compute_enc_state(request):
         backend=backend,
     )
     # CV (inner) code/state
-    states = {"p": nx_CVRHG.states["p"]}
-    CVRHG = CVLayer(DVRHG, delta=delta, states=states)
+    CVRHG = CVLayer(DVRHG, delta=delta, p_swap=p_swap)
     # Apply noise
     CVRHG.apply_noise(default_rng(seed))
     assign_weights(DVRHG, "MWPM", **weight_options)


### PR DESCRIPTION
Fix an error in initial sampling for CVLayer (SCZ matrix was applied to covariances rather than outcomes in the "initial" sampling option). Also fix an rng seed-handling error in test_stabilizer_graph.py that showed up once the above change was implemented.