### PR TITLE
Remove unused `p_err` argument

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,8 @@
 ### Bug fixes
 * Small fix in `viz.draw_EGraph` that raised an error whenever a graph state with non-integer coordinates was plotted. [#68](https://github.com/XanaduAI/flamingpy/pull/68)
 * Tutorial files are appropriately ignored in the pylint configuration file. [#65](https://github.com/XanaduAI/flamingpy/pull/65)
-* Running `simulations.py` from with command-line args was not working because the "p_err" arg was not set. This is now fixed and one can for example successfully run: `python flamingpy/simulations.py -noise "blueprint" -distance 2 -ec "primal" -boundaries "periodic" -delta 0.1 -pswap 0 -perr 0 -trials 1000 -decoder "MWPM"`. [#93](https://github.com/XanaduAI/flamingpy/pull/93) 
+* Running `simulations.py` from with command-line args was not working because the "p_err" arg was not set. This is now fixed and one can for example successfully run: `python flamingpy/simulations.py -noise "blueprint" -distance 2 -ec "primal" -boundaries "periodic" -delta 0.1 -pswap 0 -perr 0 -trials 1000 -decoder "MWPM"`. [#93](https://github.com/XanaduAI/flamingpy/pull/93)
+* Remove `p_err` as an argument of the `simulations.py` script as none of the existing objects/classes anywhere currently use the phase error probability.  [#93](https://github.com/XanaduAI/flamingpy/pull/99)
 
 ### Improvements
 
@@ -34,10 +35,11 @@
  * The `final` sampling order has been removed, as it is equivalent to `initial` but slower.
 * The `simulations.py` module has been made simpler and more general. [#57](https://github.com/XanaduAI/flamingpy/pull/57)
   * Functions within this module accept `code, noise, decoder` objects, as well as arguments (`code_args, noise_args, decoder_args`) separately.
-* Examples, benchmarks, and tests have been modified to take advantage of the simpler approach to noise application and the new `CVMacroLayer`. [#57](https://github.com/XanaduAI/flamingpy/pull/57) 
+* Examples, benchmarks, and tests have been modified to take advantage of the simpler approach to noise application and the new `CVMacroLayer`. [#57](https://github.com/XanaduAI/flamingpy/pull/57)
 * In `simulations.py`: [#93](https://github.com/XanaduAI/flamingpy/pull/93)
   * Directory argument `-d` was removed as it was unused. A working version can be added in the future.
   * We have removed reporting "decoding_total_time" as a more sophisticated time profiler feature systematically timing all the script subroutines will be added soon.
+* Added the `err_prob` argument to the `simulations.py` script in order to be able to execute the simulations with iid noise. An error is raised when iid noise is selected but err_prob is not passed as an argument.  [#93](https://github.com/XanaduAI/flamingpy/pull/99)
 
 ### Documentation changes
 

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -200,7 +200,6 @@ def run_ec_simulation(
                     "boundaries",
                     "delta",
                     "p_swap",
-                    "p_err",
                     "decoder",
                     "errors",
                     "trials",
@@ -222,7 +221,6 @@ def run_ec_simulation(
                 code_args["boundaries"],
                 noise_args.get("delta"),
                 noise_args.get("p_swap"),
-                noise_args.get("p_err"),
                 decoder,
                 errors,
                 trials,
@@ -244,7 +242,6 @@ if __name__ == "__main__":
         parser.add_argument("-boundaries", type=str)
         parser.add_argument("-delta", type=float)
         parser.add_argument("-pswap", type=float)
-        parser.add_argument("-perr", type=float)
         parser.add_argument("-trials", type=int)
         parser.add_argument("-decoder", type=str)
 
@@ -256,7 +253,6 @@ if __name__ == "__main__":
             "boundaries": args.boundaries,
             "delta": args.delta,
             "p_swap": args.pswap,
-            "p_err": args.perr,
             "trials": args.trials,
             "decoder": args.decoder,
         }
@@ -270,7 +266,6 @@ if __name__ == "__main__":
             "boundaries": "open",
             "delta": 0.09,
             "p_swap": 0.25,
-            "p_err": 0,
             "trials": 100,
             "decoder": "MWPM",
         }
@@ -287,7 +282,7 @@ if __name__ == "__main__":
     code_args = {key: params[key] for key in ["distance", "ec", "boundaries"]}
 
     noise = noise_dict[params["noise"]]
-    noise_args = {key: params[key] for key in ["delta", "p_swap", "p_err"]}
+    noise_args = {key: params[key] for key in ["delta", "p_swap"]}
 
     decoder = params["decoder"]
     args = [params["trials"], code, code_args, noise, noise_args, decoder]

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -288,6 +288,14 @@ if __name__ == "__main__":
 
     noise = noise_dict[params["noise"]]
     noise_args = {key: params[key] for key in ["delta", "p_swap"]}
+    # check that arg err_prob is provided for iid noise
+    if params.get("noise") == "iid":
+        if params.get("err_prob") is None:
+            raise ValueError(f"No argument `err_prob` found for iid noise.")
+
+        # set to None unused args and update noise_args
+        params["delta"], params["p_swap"] = None, None
+        noise_args = {"err_prob": params.get("err_prob")}
 
     decoder = params["decoder"]
     args = [params["trials"], code, code_args, noise, noise_args, decoder]

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
 
         # set to None unused args and update noise_args
         params["delta"], params["p_swap"] = None, None
-        noise_args = {"err_prob": params.get("err_prob")}
+        noise_args = {"error_probability": params.get("err_prob")}
 
     decoder = params["decoder"]
     args = {

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -200,6 +200,7 @@ def run_ec_simulation(
                     "boundaries",
                     "delta",
                     "p_swap",
+                    "err_prob",
                     "decoder",
                     "errors",
                     "trials",
@@ -221,6 +222,7 @@ def run_ec_simulation(
                 code_args["boundaries"],
                 noise_args.get("delta"),
                 noise_args.get("p_swap"),
+                noise_args.get("err_prob"),
                 decoder,
                 errors,
                 trials,
@@ -242,6 +244,7 @@ if __name__ == "__main__":
         parser.add_argument("-boundaries", type=str)
         parser.add_argument("-delta", type=float)
         parser.add_argument("-pswap", type=float)
+        parser.add_argument("-errprob", type=float)
         parser.add_argument("-trials", type=int)
         parser.add_argument("-decoder", type=str)
 
@@ -253,6 +256,7 @@ if __name__ == "__main__":
             "boundaries": args.boundaries,
             "delta": args.delta,
             "p_swap": args.pswap,
+            "err_prob": args.pswap,
             "trials": args.trials,
             "decoder": args.decoder,
         }
@@ -266,6 +270,7 @@ if __name__ == "__main__":
             "boundaries": "open",
             "delta": 0.09,
             "p_swap": 0.25,
+            "err_prob": 0.1,
             "trials": 100,
             "decoder": "MWPM",
         }

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
     # check that arg err_prob is provided for iid noise
     if params.get("noise") == "iid":
         if params.get("err_prob") is None:
-            raise ValueError(f"No argument `err_prob` found for iid noise.")
+            raise ValueError("No argument `err_prob` found for iid noise.")
 
         # set to None unused args and update noise_args
         params["delta"], params["p_swap"] = None, None

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -222,7 +222,7 @@ def run_ec_simulation(
                 code_args["boundaries"],
                 noise_args.get("delta"),
                 noise_args.get("p_swap"),
-                noise_args.get("err_prob"),
+                noise_args.get("error_probability"),
                 decoder,
                 errors,
                 trials,

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -243,8 +243,8 @@ if __name__ == "__main__":
         parser.add_argument("-ec", type=str)
         parser.add_argument("-boundaries", type=str)
         parser.add_argument("-delta", type=float)
-        parser.add_argument("-pswap", type=float)
-        parser.add_argument("-errprob", type=float)
+        parser.add_argument("-p_swap", type=float)
+        parser.add_argument("-err_prob", type=float)
         parser.add_argument("-trials", type=int)
         parser.add_argument("-decoder", type=str)
 
@@ -255,8 +255,8 @@ if __name__ == "__main__":
             "ec": args.ec,
             "boundaries": args.boundaries,
             "delta": args.delta,
-            "p_swap": args.pswap,
-            "err_prob": args.pswap,
+            "p_swap": args.p_swap,
+            "err_prob": args.err_prob,
             "trials": args.trials,
             "decoder": args.decoder,
         }

--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -298,5 +298,12 @@ if __name__ == "__main__":
         noise_args = {"err_prob": params.get("err_prob")}
 
     decoder = params["decoder"]
-    args = [params["trials"], code, code_args, noise, noise_args, decoder]
-    run_ec_simulation(*args)
+    args = {
+        "trials": params["trials"],
+        "code": code,
+        "code_args": code_args,
+        "noise": noise,
+        "noise_args": noise_args,
+        "decoder": decoder,
+    }
+    run_ec_simulation(**args)

--- a/tests/frontend/test_simulations.py
+++ b/tests/frontend/test_simulations.py
@@ -132,7 +132,7 @@ def test_simulations_output_file(tmpdir, empty_file, noise, decoder):
     """Check the content of the simulation benchmark output file."""
 
     expected_header = (
-        "noise,distance,ec,boundaries,delta,p_swap,decoder,errors,"
+        "noise,distance,ec,boundaries,delta,p_swap,err_prob,decoder,errors,"
         + "trials,current_time,simulation_time,mpi_size"
     )
 

--- a/tests/frontend/test_simulations.py
+++ b/tests/frontend/test_simulations.py
@@ -132,7 +132,7 @@ def test_simulations_output_file(tmpdir, empty_file, noise, decoder):
     """Check the content of the simulation benchmark output file."""
 
     expected_header = (
-        "noise,distance,ec,boundaries,delta,p_swap,p_err,decoder,errors,"
+        "noise,distance,ec,boundaries,delta,p_swap,decoder,errors,"
         + "trials,current_time,simulation_time,mpi_size"
     )
 


### PR DESCRIPTION
## Context for changes

None of the existing objects/classes anywhere currently use the phase error probability `p_err` as an input. On the other hand, iid noise requires the parameter `err_prob` which is currently missing.

- **New features**:
    * Adds the `err_prob` argument to the `simulations.py` script. An error is raised when iid noise is selected but `err_prob` is not passed as an argument.
- **Improvements**:
    * Remove `p_err` as an argument of the `simulations.py` script.

## Example usage and tests

The test `test_simulations_output_file` was refactored consistently by removing `p_err` from the expected columns and adding `prob_err`.

```bash
python flamingpy/simulations.py -noise iid -distance 13 -ec primal -boundaries open -delta 0.09 -p_swap 0.25 -err_prob 0.1 -trials 1000 -decoder UF
```

## Performance results justifying changes
- [x] Not Applicable

## Workflow actions and tests
- [x] Not Applicable

## Expected benefits and drawbacks

**Expected benefits:**
-  The unused argument `p_err` is no longer present.
-  `err_prob` argument allows for the use of iid noise

**Possible drawbacks:**
- None

## Related Github issues
- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
