### PR TITLE
[Hotfix] Add random number generator where missing CVMacroLayer

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* `rng` arguments are added where missing in `CVMacroLayer`. [#104](https://github.com/XanaduAI/flamingpy/pull/104)
+
 ### Improvements
 
 ### Documentation changes

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.9.0b0"
+__version__ = "0.9.0b0.dev0"

--- a/flamingpy/noise/cv.py
+++ b/flamingpy/noise/cv.py
@@ -389,7 +389,7 @@ class CVMacroLayer(CVLayer):
         effective bit values and phase error probabilities.
         """
         # Sample for the initial state types
-        self.populate_states(rng=rng)
+        self.populate_states(rng)
         # Obtain permuted indices, with stars (central nodes at the front)
         self._permute_star_inds()
         # Apply body indices to the macronode graph and effective state labels
@@ -397,9 +397,9 @@ class CVMacroLayer(CVLayer):
         self._apply_macro_and_reduced_labels()
         # Apply symplectic matrices corresponding to CZ gates and the
         # beamsplitter networks.
-        self._entangle_states()
+        self._entangle_states(rng)
         # Measure the syndrome, corresponding to memory-mode operaiton.
-        self._measure_syndrome()
+        self._measure_syndrome(rng)
         # Process homodyne outcomes to calculate effective bit values
         # and phase error probabilities for the reduced nodes.
         for j in range(0, self._N - 3, 4):
@@ -422,7 +422,7 @@ class CVMacroLayer(CVLayer):
             centre_point = tuple(round(i) for i in point)
             self.reduced_graph.nodes[centre_point]["state"] = self.egraph.nodes[point]["state"]
 
-    def _entangle_states(self):
+    def _entangle_states(self, rng=default_rng()):
         """Entangle the states in the macro_graph.
 
         Apply CZ gates to (i.e. a symplectic CZ matrix to the quadratures of)
@@ -434,7 +434,7 @@ class CVMacroLayer(CVLayer):
         vector.
         """
         N = self._N
-        quads = self._means_sampler(propagate=True)
+        quads = self._means_sampler(propagate=True, rng=rng)
         # Permute the quadrature values to align with the permuted
         # indices in order to apply the beamsplitter network.
         quad_permutation = np.concatenate([self.permuted_inds, N + self.permuted_inds])
@@ -475,7 +475,7 @@ class CVMacroLayer(CVLayer):
                 meas[index] = macro_graph.nodes[micro]["hom_val_q"]
         return meas
 
-    def _measure_syndrome(self):
+    def _measure_syndrome(self, rng=default_rng()):
         """Measure the syndrome of self.egraph.
 
         Conduct p-homodyne measurements on the stars (central modes) of
@@ -492,8 +492,8 @@ class CVMacroLayer(CVLayer):
         planets = np.delete(self.permuted_inds, np.arange(0, N, 4))
         # Update quadrature values after CZ gate application.
         # Measure stars in p, planets in q.
-        self.measure_hom(quad="p", inds=stars, updated_means=unpermuted_quads)
-        self.measure_hom(quad="q", inds=planets, updated_means=unpermuted_quads)
+        self.measure_hom(quad="p", inds=stars, updated_means=unpermuted_quads, rng=rng)
+        self.measure_hom(quad="q", inds=planets, updated_means=unpermuted_quads, rng=rng)
 
     def _neighbor_of_micro_i_macro_j(self, i, j):
         """Return the neighbor of the ith micronode, jth macronode in


### PR DESCRIPTION
## Context for changes

Not all methods of `CVMacroLayer` in which random sampling is used have an `rng` argument, and some methods are not fed an `rng` argument.  

- **Bug fixes**:
    * `rng` arguments are included in missing places in `CVMacroLayer`. 

## Example usage and tests

- [x] Not Applicable

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable

## Expected benefits and drawbacks

**Expected benefits:**
- Reproducibility of CV macronode simulations involving randomness is made possible.
- Randomness is appropriately treated in multithreaded simulations.

**Possible drawbacks:**
- None.

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.