### PR TITLE
Use semicolons `;` instead of commas `,` as separator in simulation data files 🗄️ 

### DIFF
--- a/flamingpy/simulations.py
+++ b/flamingpy/simulations.py
@@ -155,35 +155,35 @@ def run_ec_simulation(
         # Create a CSV file if it doesn't already exist.
         try:
             file = open(file_name, "x", newline="", encoding="utf8")
-            file.write("code,")
+            file.write("code;")
             for key in code_args:
-                file.write("%s," % (key))
-            file.write("noise,")
+                file.write("%s;" % (key))
+            file.write("noise;")
             for key in noise_args:
-                file.write("%s," % (key))
-            file.write("decoder,")
+                file.write("%s;" % (key))
+            file.write("decoder;")
             for key in decoder_args:
-                file.write("%s," % (key))
-            file.write("errors,trials,current_time,simulation_time,mpi_size\n")
+                file.write("%s;" % (key))
+            file.write("errors;trials;current_time;simulation_time;mpi_size\n")
         # Open the file for appending if it already exists.
         except FileExistsError:
             file = open(file_name, "a", newline="", encoding="utf8")
             # writer = csv.writer(file)
-        file.write("%s," % (code.__name__))
+        file.write("%s;" % (code.__name__))
         for value in code_args.values():
-            file.write("%s," % (value))
-        file.write("%s," % (noise.__name__))
+            file.write("%s;" % (value))
+        file.write("%s;" % (noise.__name__))
         for value in noise_args.values():
-            file.write("%s," % (value))
-        file.write("%s," % (decoder))
+            file.write("%s;" % (value))
+        file.write("%s;" % (decoder))
         for key, value in decoder_args.items():
             if key == "weight_opts":
-                file.write('"%s",' % (value))
+                file.write('"%s";' % (value))
             else:
-                file.write("%s," % (value))
+                file.write("%s;" % (value))
         current_time = datetime.now().time().strftime("%H:%M:%S")
         file.write(
-            "%i,%i,%s,%f,%i\n"
+            "%i;%i;%s;%f;%i\n"
             % (
                 errors,
                 trials,

--- a/tests/frontend/test_simulations.py
+++ b/tests/frontend/test_simulations.py
@@ -139,14 +139,14 @@ def test_simulations_output_file(tmpdir, empty_file, noise, decoder):
     if noise in ["CVLayer", "CVMacroLayer"]:
         noise_args = {"delta": 0.09, "p_swap": 0.25}
         expected_header = (
-            "code,distance,ec,boundaries,noise,delta,p_swap,decoder,weight_opts,"
-            + "errors,trials,current_time,simulation_time,mpi_size"
+            "code;distance;ec;boundaries;noise;delta;p_swap;decoder;weight_opts;"
+            + "errors;trials;current_time;simulation_time;mpi_size"
         )
     else:
         noise_args = {"error_probability": 0.1}
         expected_header = (
-            "code,distance,ec,boundaries,noise,error_probability,decoder,weight_opts,"
-            + "errors,trials,current_time,simulation_time,mpi_size"
+            "code;distance;ec;boundaries;noise;error_probability;decoder;weight_opts;"
+            + "errors;trials;current_time;simulation_time;mpi_size"
         )
     noise_dict = {"CVLayer": CVLayer, "CVMacroLayer": CVMacroLayer, "IidNoise": IidNoise}
     noise = noise_dict[noise]
@@ -171,4 +171,4 @@ def test_simulations_output_file(tmpdir, empty_file, noise, decoder):
     assert file_lines[0] == expected_header + "\n"
 
     # contents has the expected number of columns
-    assert len(re.split(",", file_lines[-1])) == len(re.split(",", expected_header))
+    assert len(re.split(";", file_lines[-1])) == len(re.split(";", expected_header))


### PR DESCRIPTION
## Context for changes

Use semicolons as separators instead of commas when writing files. This prevents confusion between dictionary entries and actual column separators which started happening after #111.

- **Improvements**:
    * Use semicolon as separator instead of comma to prevent confusion between column separators and dictionary item separators.

## Example usage and tests

- [x] Not Applicable


## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Tests adjusted accordingly


## Expected benefits and drawbacks

**Expected benefits:**
- Data can easily be read from data files using e.g. Pandas

**Possible drawbacks:**
- User should beware of change in data file structure and use `sep=";"`

## Related Github issues

- The current data storage format was introduced in #111 

## Checklist and integration statements

- [ ] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
