### PR TITLE
[HOTFIX] Update `setup.py` to allow `git` installation with `pip`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,7 +12,8 @@
     code,distance,ec,boundaries,noise,delta,p_swap,decoder,weight_opts,errors,trials,current_time,simulation_time,mpi_size
     SurfaceCode,3,primal,open,CVLayer,0.09,0.25,MWPM,{'method': 'blueprint', 'integer': False, 'multiplier': 1, 'delta': 0.09},10,100,00:15:50,0.370795,1
     ```
-* Added Plotly backend for visualizing graph states [#103](https://github.com/XanaduAI/flamingpy/pull/103)
+* Added Plotly backend for visualizing graph states. [#103](https://github.com/XanaduAI/flamingpy/pull/103)
+* Users can install FlamingPy from git with pip. [#118](https://github.com/XanaduAI/flamingpy/pull/118)
 
 ### Bug fixes
 

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.9.1b0.dev3"
+__version__ = "0.9.1b0.dev4"

--- a/setup.py
+++ b/setup.py
@@ -123,10 +123,12 @@ if sys.argv[1] == "build_cython":
     ]
 elif sys.argv[1] == "build_cmake":
     ext_modules = [CMakeExtension("flamingpy.cpp.lemonpy")]
-elif sys.argv[1] == "install" or sys.argv[1] == "develop" or sys.argv[1] == "bdist_wheel":
+elif sys.argv[1] in ("install", "develop", "bdist_wheel", "egg_info"):
     ext_modules = []
 else:
-    ext_modules = []
+    raise NotImplementedError(
+        f"'{sys.argv[1]}' is not a recognized argument for setup.py of FlamingPy"
+    )
 
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ elif sys.argv[1] == "build_cmake":
 elif sys.argv[1] == "install" or sys.argv[1] == "develop" or sys.argv[1] == "bdist_wheel":
     ext_modules = []
 else:
-    raise NotImplementedError
+    ext_modules = []
 
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Context for changes

Allowing users to install FlamingPy from git with `pip`
```
pip install git+https://github.com/XanaduAI/flamingpy
``` 
This is especially useful if a user wants to set up an environment with a particular branch. One simply has to specify the branch by adding `@branch` at the end: `git+https://github.com/XanaduAI/flamingpy@mbqc-demo`. For the implementation: I simply added `"egg_info"` as an input option to `setup.py`. The option will then default to using no extensions (such as the `lemonpy` C++ extension)

- **New features**:
    * Users can use `pip install git+https://github.com/XanaduAI/flamingpy` to directly `pip` install from git.

## Example usage and tests

Users can use `pip install git+https://github.com/XanaduAI/flamingpy`. To specify a particular branch, use `pip install git+https://github.com/XanaduAI/flamingpy@branch` where `branch` is the desired branch name. This can be useful when a special feature branch is needed in environments outside of `flaminpy`

## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable

## Expected benefits and drawbacks

See description above

## Related Github issues

- https://github.com/PennyLaneAI/qml/pull/485, commit https://github.com/PennyLaneAI/qml/pull/485/commits/230e8d14360e2ccb5ef4f9beaedfb12dc9a50824

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
