### PR TITLE
[Hotfix] Deletion of remaining Cython lines

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-* Our Cython example and instructions were removed on [#109](https://github.com/XanaduAI/flamingpy/pull/109), however, there were some leftover Cython tests in parts of the code including main `__init__.py`. These unnecessary Cython lines are now fully removed. [#122](https://github.com/XanaduAI/flamingpy/pull/122)
+* Our Cython example and instructions were removed on [#119](https://github.com/XanaduAI/flamingpy/pull/119), however, there were some leftover Cython tests in parts of the code including main `__init__.py`. These unnecessary Cython lines are now fully removed. [#122](https://github.com/XanaduAI/flamingpy/pull/122)
 
 ### Documentation changes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ### Improvements
 
+* Our Cython example and instructions were removed on [#109](https://github.com/XanaduAI/flamingpy/pull/109), however, there were some leftover Cython tests in parts of the code including main `__init__.py`. These unnecessary Cython lines are now fully removed. [#122](https://github.com/XanaduAI/flamingpy/pull/122)
+
 ### Documentation changes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Nariman Saadatmand
 
 See full commit details ...
 

--- a/flamingpy/__init__.py
+++ b/flamingpy/__init__.py
@@ -27,7 +27,6 @@ import matplotlib
 
 try:
     import flamingpy.cpp.lemonpy as lp
-    import flamingpy.cpp.cpp_mc_loop as cmc
 
     cpp_libraries_available = True
 except ImportError:  # pragma: no cover
@@ -75,10 +74,5 @@ def about():
     print(
         "lemonpy shared object:       {}".format(
             "Not installed" if not cpp_libraries_available else lp
-        )
-    )
-    print(
-        "cpp_mc_loop shared object:   {}".format(
-            "Not installed" if not cpp_libraries_available else cmc
         )
     )

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.10.1b1"
+__version__ = "0.10.1b1.dev0"

--- a/tests/decoders/test_matching.py
+++ b/tests/decoders/test_matching.py
@@ -34,7 +34,6 @@ from flamingpy.noise import CVLayer
 
 try:
     import flamingpy.cpp.lemonpy as lp
-    import flamingpy.cpp.cpp_mc_loop as cmc
 
     cpp_libraries_available = True
 except ImportError:  # pragma: no cover

--- a/tests/frontend/test_init.py
+++ b/tests/frontend/test_init.py
@@ -46,4 +46,3 @@ def test_about():
     assert "RetworkX version:" in out
     assert "Matplotlib version:" in out
     assert "lemonpy shared object:" in out
-    assert "cpp_mc_loop shared object:" in out


### PR DESCRIPTION
## Context for changes

In #119, we have removed our Cython example and instructions. However, I have missed removing Cython tests in parts of the code, specifically main `__init__.py`. These are now all removed in this PR. 

- **Improvements**:
    * Our Cython example and instructions were removed on #119, however, there were some leftover Cython tests in parts of the code including main `__init__.py`. These unnecessary Cython lines are now fully removed. 

## Example usage and tests

- [x] Not Applicable


## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable


## Expected benefits and drawbacks

**Expected benefits:**
- All unnecessary Cythin lines were removed.

## Related Github issues

Relates to #119. 

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
