### PR TITLE
Remove tight layout setting from draw_EGraph_matplotlib, remove docformatter from workflow

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Bug fixes
 
-* `retworkx` package was renamed to `rustworkx`, and its version upgraded, to reflect the package's name change and resolve error when running `flamingpy.about`. [#124](https://github.com/XanaduAI/flamingpy/pull/124).
-* An instance of a depracated `fig.gca` with a keyword argument was fixed. [#124](https://github.com/XanaduAI/flamingpy/pull/124).
+* `retworkx` package was renamed to `rustworkx`, and its version upgraded, to reflect the package's name change and resolve error when running `flamingpy.about`. [#124](https://github.com/XanaduAI/flamingpy/pull/124)
+* An instance of a depracated `fig.gca` with a keyword argument was fixed. [#124](https://github.com/XanaduAI/flamingpy/pull/124)
+* Remove the tight layout setting from `draw_EGraph_matplotlib`, which was causing a warning. [#125](https://github.com/XanaduAI/flamingpy/pull/125)
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Our Cython example and instructions were removed on [#119](https://github.com/XanaduAI/flamingpy/pull/119), however, there were some leftover Cython tests in parts of the code including main `__init__.py`. These unnecessary Cython lines are now fully removed. [#122](https://github.com/XanaduAI/flamingpy/pull/122)
 * Modify `dev_requirements` to install `black` version 23.1.0, and format all files with this version. [#124](https://github.com/XanaduAI/flamingpy/pull/124).
+* Remove `docformatter` check from workflow as it did not have great importance. [#125](https://github.com/XanaduAI/flamingpy/pull/125)
 
 ### Documentation changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@
 
 ## Checklist and integration statements
 
-- [ ] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
+- [ ] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black` and `pylint` configurations.
 - [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
 - [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
 - [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -12,7 +12,7 @@ on:
       - sims2cloud
 
 jobs:
-  black-n-docformatter:
+  run-black:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -23,12 +23,9 @@ jobs:
       - name: Get the latest pip and black
         run: |
           python -m pip install --upgrade pip
-          python -m pip install black docformatter --upgrade
+          python -m pip install black --upgrade
 
       - uses: actions/checkout@v2
 
       - name: Run black
         run: python -m black -l 100 tests flamingpy doc --check
-
-      - name: Run docformatter
-        run: python -m docformatter -r --check .

--- a/.pylintrc
+++ b/.pylintrc
@@ -27,4 +27,4 @@ ignored-classes=numpy,scipy,networkx,flamingpy.codes
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=invalid-name,consider-using-f-string,too-many-branches,no-member,redefined-outer-name,too-many-arguments,too-many-locals,too-few-public-methods,no-self-use,use-dict-literal
+disable=invalid-name,consider-using-f-string,too-many-branches,no-member,redefined-outer-name,too-many-arguments,too-many-locals,too-few-public-methods,no-self-use,use-dict-literal, broad-exception-raised

--- a/.pylintrc
+++ b/.pylintrc
@@ -27,4 +27,4 @@ ignored-classes=numpy,scipy,networkx,flamingpy.codes
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=invalid-name,consider-using-f-string,too-many-branches,no-member,redefined-outer-name,too-many-arguments,too-many-locals,too-few-public-methods,no-self-use
+disable=invalid-name,consider-using-f-string,too-many-branches,no-member,redefined-outer-name,too-many-arguments,too-many-locals,too-few-public-methods,no-self-use,use-dict-literal

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,6 @@
 black>=23.1.0
 cmake>=3.14
 codecov>=2.1.12
-docformatter>=1.5
 matplotlib>=3.3.3
 networkx>=2.5
 numpy>=1.21

--- a/doc/development/guide_for_devs.rst
+++ b/doc/development/guide_for_devs.rst
@@ -13,7 +13,6 @@ as well as the following Python packages for development purposes:
 * |black| >= 23.1.0
 * |cmake| >= 3.14
 * |codecov| >= 2.1.12
-* |docformatter| >= 1.5
 * |matplotlib| >= 3.3.3
 * |mpi4py| >= 3.1.3 (optional, only for Linux users)
 * |networkx| >= 2.5
@@ -145,10 +144,6 @@ See :doc:`build_docs` for the details on how to build the HTML documentation.
 .. |codecov| raw:: html
 
    <a href="https://about.codecov.io/language/python/" target="_blank">codecov</a>
-
-.. |docformatter| raw:: html
-
-   <a href="https://pypi.org/project/docformatter/" target="_blank">docformatter</a>
 
 .. |matplotlib| raw:: html
 

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.10.1b1.dev1"
+__version__ = "0.10.1b1.dev2"

--- a/flamingpy/utils/viz.py
+++ b/flamingpy/utils/viz.py
@@ -343,7 +343,6 @@ def draw_EGraph_matplotlib(
     ax.set_zlabel("y", labelpad=15)
     if not show_axes:
         ax.axis("off")
-    plt.tight_layout(pad=5)
     plt.draw()
 
     return fig, ax


### PR DESCRIPTION
## Context for changes

- Tight layout setting from `draw_EGraph_matplotlib` as it was causing a warning. 
- Docformatter was causing issues.
- 
- **Bug fixes**:
    * Remove the tight layout setting from `draw_EGraph_matplotlib`.
    * Remove `docformatter` from workflow.

## Example usage and tests

- [x] Not Applicable


## Performance results justifying changes

- [x] Not Applicable

## Workflow actions and tests

- [x] Not Applicable


## Expected benefits and drawbacks

**Expected benefits:**
- Warning no longer displayed.

**Possible drawbacks:**
- It is possible that some EGraph plots will be awkwardly cut off.

## Related Github issues

- [x] Not Applicable

## Checklist and integration statements

- [x] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black`, `docformatter` and `pylint` configurations.
- [x] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [x] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [x] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [x] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
