### PR TITLE
use v4 artifact

### DIFF
--- a/.github/workflows/upload_macos_x64.yaml
+++ b/.github/workflows/upload_macos_x64.yaml
@@ -47,7 +47,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifact${{matrix.python-version}}
           path: dist/*.whl
@@ -56,7 +56,7 @@ jobs:
     needs: macos-x64-wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           path: dist
 

--- a/.github/workflows/upload_win_x64.yaml
+++ b/.github/workflows/upload_win_x64.yaml
@@ -53,7 +53,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifact${{matrix.python-version}}
           path: dist/*.whl
@@ -62,7 +62,7 @@ jobs:
     needs: win-x64-wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           path: dist
 

--- a/flamingpy/_version.py
+++ b/flamingpy/_version.py
@@ -14,4 +14,4 @@
 """Version number (major.minor.patch[label])"""
 
 
-__version__ = "0.10.1b1.dev3"
+__version__ = "0.10.1b1.dev5"


### PR DESCRIPTION
## Context for changes and related issues
The v3 (and under) artifact actions are deprecated, and [must be updated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) by end of January.

### Improvements
- Bump the `upload-artifact` and `download-artifact` versions to `v4`

## Benefits, drawbacks, and extensions 
- Our wheel upload actions won't suddenly break in February

## Checklist and integration statements

- [ ] My Python and C++ codes follow this project's coding and commenting styles as indicated by existing files. Precisely, the changes conform to given `black` and `pylint` configurations.
- [ ] I have performed a self-review of these changes, checked my code (including for [codefactor](https://www.codefactor.io/repository/github/xanaduai/flamingpy/branches) compliance), and corrected misspellings to the best of my capacity. I have synced this branch with others as required.
- [ ] I have added context for corresponding changes in documentation and [`README.md`](README.md) as needed.
- [ ] I have added new workflow CI tests for corresponding changes, ensuring codecoverage is 95% or better, and these pass locally for me.
- [ ] I have updated [`CHANGELOG.md`](.github/CHANGELOG.md) following the template. I recognize that the developers may revisit [`CHANGELOG.md`](.github/CHANGELOG.md) and the versioning, and create a Special Release including my changes.
